### PR TITLE
Add SOLID example crate

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -1,0 +1,35 @@
+# Example Crate
+
+This directory provides a minimal Rust crate named `example_crate` that
+illustrates how to organize code following SOLID principles.
+The layout keeps traits, implementations and services in separate
+folders so that components remain easy to test and extend.
+
+```
+example_crate/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── traits/
+│   │   └── greeter.rs
+│   ├── implementations/
+│   │   └── english_greeter.rs
+│   └── services/
+│       └── greeting_service.rs
+└── tests/
+    └── greeting_service_tests.rs
+```
+
+`traits` defines abstractions (`Greeter`) that services depend on.
+Concrete implementations live in the `implementations` folder. Services
+compose these implementations through generic parameters, enabling loose
+coupling and straightforward unit testing.
+
+Run the tests with:
+
+```bash
+cargo test --manifest-path Docs/examples/example_crate/Cargo.toml
+```
+
+This crate is intended as reference code for agents wanting to build
+manageable, well-structured crates.

--- a/Docs/examples/example_crate/Cargo.toml
+++ b/Docs/examples/example_crate/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example_crate"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[dev-dependencies]

--- a/Docs/examples/example_crate/src/implementations/english_greeter.rs
+++ b/Docs/examples/example_crate/src/implementations/english_greeter.rs
@@ -1,0 +1,9 @@
+use crate::traits::Greeter;
+
+pub struct EnglishGreeter;
+
+impl Greeter for EnglishGreeter {
+    fn greet(&self, name: &str) -> String {
+        format!("Hello, {name}!")
+    }
+}

--- a/Docs/examples/example_crate/src/implementations/mod.rs
+++ b/Docs/examples/example_crate/src/implementations/mod.rs
@@ -1,0 +1,3 @@
+pub mod english_greeter;
+
+pub use english_greeter::EnglishGreeter;

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -1,0 +1,5 @@
+#![forbid(unsafe_code)]
+
+pub mod implementations;
+pub mod services;
+pub mod traits;

--- a/Docs/examples/example_crate/src/services/greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/greeting_service.rs
@@ -1,0 +1,15 @@
+use crate::traits::Greeter;
+
+pub struct GreetingService<G: Greeter> {
+    greeter: G,
+}
+
+impl<G: Greeter> GreetingService<G> {
+    pub fn new(greeter: G) -> Self {
+        Self { greeter }
+    }
+
+    pub fn send_greeting(&self, name: &str) -> String {
+        self.greeter.greet(name)
+    }
+}

--- a/Docs/examples/example_crate/src/services/mod.rs
+++ b/Docs/examples/example_crate/src/services/mod.rs
@@ -1,0 +1,3 @@
+pub mod greeting_service;
+
+pub use greeting_service::GreetingService;

--- a/Docs/examples/example_crate/src/traits/greeter.rs
+++ b/Docs/examples/example_crate/src/traits/greeter.rs
@@ -1,0 +1,3 @@
+pub trait Greeter {
+    fn greet(&self, name: &str) -> String;
+}

--- a/Docs/examples/example_crate/src/traits/mod.rs
+++ b/Docs/examples/example_crate/src/traits/mod.rs
@@ -1,0 +1,3 @@
+pub mod greeter;
+
+pub use greeter::Greeter;

--- a/Docs/examples/example_crate/tests/greeting_service_tests.rs
+++ b/Docs/examples/example_crate/tests/greeting_service_tests.rs
@@ -1,0 +1,8 @@
+use example_crate::implementations::EnglishGreeter;
+use example_crate::services::GreetingService;
+
+#[test]
+fn greeting_service_returns_expected_greeting() {
+    let service = GreetingService::new(EnglishGreeter);
+    assert_eq!(service.send_greeting("Alice"), "Hello, Alice!");
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ that participants write bots, improve bots and let the system run tournaments to
 
 You know C++? C#? Great, Rust provides a good way to get you finally into productive mode, especially if you are working with threads or low level code.
 
+## Documentation
+
+Additional documentation can be found in the `Docs/` directory. A minimal
+reference crate showing SOLID code organization lives in
+`Docs/examples/example_crate`.
+

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -86,7 +86,7 @@ impl Game {
             map_settings,
             map,
             bots: players,
-            player_count: player_count,
+            player_count,
             turn: 0,
             shrink_at_turn: endgame,
             player_actions: Vec::new(),
@@ -94,8 +94,8 @@ impl Game {
             // initialize alive player and shuffle them
             alive_players: Vec::new(),
             bomb_range: 3, // Default bomb range, can be adjusted as needed
-            width: width,
-            height: height,
+            width,
+            height,
             display: Box::new(ConsoleDisplay),
         }
     }
@@ -191,13 +191,13 @@ impl Game {
                 if let Some(player_index) = self.map.get_player_index_at_location(shrink_location) {
                     // Remove the player from the game
                     let playername = self.map.get_player_name(player_index);
-                    if let Some(player_name) = playername
-                        && let Some(cb) = logging_callback
-                    {
-                        cb(format!(
-                            "Player {} has been removed from the game due to shrinking at location {:?}",
-                            player_name, shrink_location
-                        ));
+                    if let Some(player_name) = playername {
+                        if let Some(cb) = logging_callback {
+                            cb(format!(
+                                "Player {} has been removed from the game due to shrinking at location {:?}",
+                                player_name, shrink_location
+                            ));
+                        }
                     }
 
                     self.alive_players.retain(|&x| x != player_index);

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -72,8 +72,8 @@ impl Map {
                 .cloned()
                 .zip(player_locations.iter().cloned())
                 .map(|(name, position)| Player {
-                    name: name,
-                    position: position, // Initial position will be set later
+                    name,
+                    position, // Initial position will be set later
                 })
                 .collect(),
             bombs: Vec::new(),


### PR DESCRIPTION
## Summary
- add docs with example crate demonstrating SOLID layout
- show how to organise traits, implementations and services
- fix clippy errors in game and map modules
- reference docs in main README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy and other warnings)*
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68836325ea34832db71f5b1623f22340