### PR TITLE
Add example crate in docs

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -1,0 +1,7 @@
+# Examples Directory
+
+This directory contains self-contained examples illustrating how to structure code
+following the principles outlined in the architecture document.
+
+The `example_crate` subdirectory is a tiny crate demonstrating SOLID design. It
+is not part of the workspace and can be explored independently.

--- a/Docs/examples/example_crate/Cargo.toml
+++ b/Docs/examples/example_crate/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example_crate"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[dev-dependencies]
+

--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -1,0 +1,11 @@
+# Example Crate
+
+This crate demonstrates a minimal SOLID architecture. It provides small modules
+and traits so that agents can use it as a reference for clean, maintainable code.
+
+- `src/traits` contains trait definitions that decouple behavior from
+  implementations.
+- `src/examples` provides simple example implementations using the traits.
+- Unit tests showcase how the modules work together.
+
+The code is intentionally concise, focusing on clarity and good structure.

--- a/Docs/examples/example_crate/src/examples/console_messenger.rs
+++ b/Docs/examples/example_crate/src/examples/console_messenger.rs
@@ -1,0 +1,11 @@
+use crate::traits::Messenger;
+
+/// Simple `Messenger` implementation that prints to stdout.
+#[derive(Default)]
+pub struct ConsoleMessenger;
+
+impl Messenger for ConsoleMessenger {
+    fn send_message(&self, msg: &str) {
+        println!("{}", msg);
+    }
+}

--- a/Docs/examples/example_crate/src/examples/greeter.rs
+++ b/Docs/examples/example_crate/src/examples/greeter.rs
@@ -1,0 +1,19 @@
+use crate::traits::Messenger;
+
+/// Greeter uses a `Messenger` to greet users.
+pub struct Greeter<'a, M: Messenger> {
+    messenger: &'a M,
+}
+
+impl<'a, M: Messenger> Greeter<'a, M> {
+    /// Create a new `Greeter` with the given messenger.
+    pub fn new(messenger: &'a M) -> Self {
+        Self { messenger }
+    }
+
+    /// Greet a user by name.
+    pub fn greet(&self, name: &str) {
+        let msg = format!("Hello, {name}!");
+        self.messenger.send_message(&msg);
+    }
+}

--- a/Docs/examples/example_crate/src/examples/mod.rs
+++ b/Docs/examples/example_crate/src/examples/mod.rs
@@ -1,0 +1,7 @@
+//! Example implementations using the crate traits.
+
+mod console_messenger;
+mod greeter;
+
+pub use console_messenger::ConsoleMessenger;
+pub use greeter::Greeter;

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -1,0 +1,5 @@
+#![forbid(unsafe_code)]
+//! Minimal example crate demonstrating SOLID architecture.
+
+pub mod traits;
+pub mod examples;

--- a/Docs/examples/example_crate/src/traits/mod.rs
+++ b/Docs/examples/example_crate/src/traits/mod.rs
@@ -1,0 +1,7 @@
+//! Collection of trait definitions used throughout the example crate.
+
+/// Abstraction for sending messages.
+pub trait Messenger {
+    /// Send a message.
+    fn send_message(&self, msg: &str);
+}

--- a/Docs/examples/example_crate/tests/greeter_tests.rs
+++ b/Docs/examples/example_crate/tests/greeter_tests.rs
@@ -1,0 +1,22 @@
+use example_crate::examples::{Greeter};
+use example_crate::traits::Messenger;
+
+#[derive(Default)]
+struct MockMessenger {
+    sent: std::sync::Mutex<Vec<String>>,
+}
+
+impl Messenger for MockMessenger {
+    fn send_message(&self, msg: &str) {
+        self.sent.lock().unwrap().push(msg.to_string());
+    }
+}
+
+#[test]
+fn greet_sends_message() {
+    let messenger = MockMessenger::default();
+    let greeter = Greeter::new(&messenger);
+    greeter.greet("Alice");
+    let messages = messenger.sent.lock().unwrap();
+    assert_eq!(messages.as_slice(), ["Hello, Alice!"]);
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ that participants write bots, improve bots and let the system run tournaments to
 
 You know C++? C#? Great, Rust provides a good way to get you finally into productive mode, especially if you are working with threads or low level code.
 
+See [Docs/examples/example_crate](Docs/examples/example_crate) for a minimal example crate demonstrating SOLID design.


### PR DESCRIPTION
## Summary
- add example documentation folder
- provide an `example_crate` showing SOLID code organization
- include unit test demonstrating usage
- link to the example crate from the project README

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: `let` expressions in this position are unstable)*
- `cargo test --all` *(fails to compile `rust-bomberman` crate)*
- `cargo test` in `Docs/examples/example_crate`

------
https://chatgpt.com/codex/tasks/task_e_68836325ea34832db71f5b1623f22340