### PR TITLE
Add documentation to example crate

### DIFF
--- a/Docs/examples/example_crate/src/implementations/english_greeter.rs
+++ b/Docs/examples/example_crate/src/implementations/english_greeter.rs
@@ -1,5 +1,8 @@
+//! Implementation of [`Greeter`](crate::traits::Greeter) that outputs messages in English.
+
 use crate::traits::Greeter;
 
+/// Greeter implementation that produces English messages.
 pub struct EnglishGreeter;
 
 impl Greeter for EnglishGreeter {

--- a/Docs/examples/example_crate/src/implementations/mod.rs
+++ b/Docs/examples/example_crate/src/implementations/mod.rs
@@ -1,3 +1,5 @@
+//! Collection of concrete [`Greeter`](crate::traits::Greeter) implementations.
+
 pub mod english_greeter;
 
 pub use english_greeter::EnglishGreeter;

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -1,5 +1,15 @@
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
+//! Example crate demonstrating a basic layered architecture.
+//!
+//! This crate defines a [`Greeter`] trait along with a simple English
+//! implementation and a [`GreetingService`] that composes a greeter to
+//! produce greeting messages.
+
+/// Concrete implementations of the [`Greeter`] trait.
 pub mod implementations;
+/// Service layer types built on top of [`Greeter`] implementations.
 pub mod services;
+/// Core abstractions used by this crate.
 pub mod traits;

--- a/Docs/examples/example_crate/src/services/greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/greeting_service.rs
@@ -1,14 +1,19 @@
+//! Service implementations that make use of [`Greeter`](crate::traits::Greeter).
+
 use crate::traits::Greeter;
 
+/// Service that delegates greeting creation to a [`Greeter`].
 pub struct GreetingService<G: Greeter> {
     greeter: G,
 }
 
 impl<G: Greeter> GreetingService<G> {
+    /// Create a new service backed by the provided `greeter`.
     pub fn new(greeter: G) -> Self {
         Self { greeter }
     }
 
+    /// Generate a greeting for `name`.
     pub fn send_greeting(&self, name: &str) -> String {
         self.greeter.greet(name)
     }

--- a/Docs/examples/example_crate/src/services/mod.rs
+++ b/Docs/examples/example_crate/src/services/mod.rs
@@ -1,3 +1,5 @@
+//! Service layer built on top of [`Greeter`](crate::traits::Greeter) implementations.
+
 pub mod greeting_service;
 
 pub use greeting_service::GreetingService;

--- a/Docs/examples/example_crate/src/traits/greeter.rs
+++ b/Docs/examples/example_crate/src/traits/greeter.rs
@@ -1,3 +1,7 @@
+//! Trait definitions for the example crate.
+
+/// Defines behavior for generating greeting messages.
 pub trait Greeter {
+    /// Produce a greeting for the provided `name`.
     fn greet(&self, name: &str) -> String;
 }

--- a/Docs/examples/example_crate/src/traits/mod.rs
+++ b/Docs/examples/example_crate/src/traits/mod.rs
@@ -1,3 +1,5 @@
+//! Core traits used across the example.
+
 pub mod greeter;
 
 pub use greeter::Greeter;


### PR DESCRIPTION
## Summary
- enable `missing_docs` lint for example crate
- document the crate purpose
- add API docs for `Greeter` trait
- document `EnglishGreeter` and `GreetingService`
- add module docs throughout the example crate

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` within example crate
- `cargo test` within example crate
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy, needless-borrow, etc.)*
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68837192f8b0832db97b58a2891a6451