### PR TITLE
Add property-based tests for greeting service

### DIFF
--- a/Docs/examples/example_crate/Cargo.toml
+++ b/Docs/examples/example_crate/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 
 [dev-dependencies]
+proptest = "1.4"

--- a/Docs/examples/example_crate/tests/greeting_service_tests.rs
+++ b/Docs/examples/example_crate/tests/greeting_service_tests.rs
@@ -1,8 +1,18 @@
 use example_crate::implementations::EnglishGreeter;
 use example_crate::services::GreetingService;
+use proptest::prelude::*;
 
 #[test]
 fn greeting_service_returns_expected_greeting() {
     let service = GreetingService::new(EnglishGreeter);
     assert_eq!(service.send_greeting("Alice"), "Hello, Alice!");
+}
+
+proptest! {
+    #[test]
+    fn greeting_service_prop(name in "[A-Za-z]{1,16}") {
+        let service = GreetingService::new(EnglishGreeter);
+        let expected = format!("Hello, {name}!");
+        prop_assert_eq!(service.send_greeting(&name), expected);
+    }
 }


### PR DESCRIPTION
## Summary
- add `proptest` as a dev-dependency in the example crate
- introduce `greeting_service_prop` property test using `proptest`

## Testing
- `cargo clippy --manifest-path Docs/examples/example_crate/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml --quiet`
- `cargo test --all --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone_on_copy, needless_borrow, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68837535f748832d8fdfdaf1a94fd6bb