### PR TITLE
Add formatter for greetings

### DIFF
--- a/Docs/examples/example_crate/src/helpers/formatter.rs
+++ b/Docs/examples/example_crate/src/helpers/formatter.rs
@@ -1,0 +1,16 @@
+//! Utilities for formatting greeting messages.
+
+/// Trait defining a formatter for greeting messages.
+pub trait GreetingFormatter {
+    /// Format the provided `msg` and return the resulting `String`.
+    fn format(&self, msg: &str) -> String;
+}
+
+/// Formatter that appends a smiley emoji to the message.
+pub struct EmojiFormatter;
+
+impl GreetingFormatter for EmojiFormatter {
+    fn format(&self, msg: &str) -> String {
+        format!("{msg} \u{1F60A}")
+    }
+}

--- a/Docs/examples/example_crate/src/helpers/mod.rs
+++ b/Docs/examples/example_crate/src/helpers/mod.rs
@@ -1,0 +1,5 @@
+//! Helper utilities for the example crate.
+
+pub mod formatter;
+
+pub use formatter::{EmojiFormatter, GreetingFormatter};

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -11,5 +11,7 @@
 pub mod implementations;
 /// Service layer types built on top of [`Greeter`] implementations.
 pub mod services;
+/// Miscellaneous helper utilities.
+pub mod helpers;
 /// Core abstractions used by this crate.
 pub mod traits;

--- a/Docs/examples/example_crate/src/services/greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/greeting_service.rs
@@ -1,20 +1,40 @@
 //! Service implementations that make use of [`Greeter`](crate::traits::Greeter).
 
+use crate::helpers::GreetingFormatter;
 use crate::traits::Greeter;
 
 /// Service that delegates greeting creation to a [`Greeter`].
 pub struct GreetingService<G: Greeter> {
     greeter: G,
+    formatter: Option<Box<dyn GreetingFormatter>>,
 }
 
 impl<G: Greeter> GreetingService<G> {
     /// Create a new service backed by the provided `greeter`.
     pub fn new(greeter: G) -> Self {
-        Self { greeter }
+        Self {
+            greeter,
+            formatter: None,
+        }
+    }
+
+    /// Create a new service backed by the provided `greeter` and `formatter`.
+    pub fn with_formatter(
+        greeter: G,
+        formatter: Box<dyn GreetingFormatter>,
+    ) -> Self {
+        Self {
+            greeter,
+            formatter: Some(formatter),
+        }
     }
 
     /// Generate a greeting for `name`.
     pub fn send_greeting(&self, name: &str) -> String {
-        self.greeter.greet(name)
+        let msg = self.greeter.greet(name);
+        match &self.formatter {
+            Some(f) => f.format(&msg),
+            None => msg,
+        }
     }
 }

--- a/Docs/examples/example_crate/tests/greeting_service_tests.rs
+++ b/Docs/examples/example_crate/tests/greeting_service_tests.rs
@@ -1,4 +1,5 @@
 use example_crate::implementations::EnglishGreeter;
+use example_crate::helpers::EmojiFormatter;
 use example_crate::services::GreetingService;
 use proptest::prelude::*;
 
@@ -8,11 +9,30 @@ fn greeting_service_returns_expected_greeting() {
     assert_eq!(service.send_greeting("Alice"), "Hello, Alice!");
 }
 
+#[test]
+fn greeting_service_formats_output_with_emoji() {
+    let service = GreetingService::with_formatter(
+        EnglishGreeter,
+        Box::new(EmojiFormatter),
+    );
+    assert_eq!(service.send_greeting("Alice"), "Hello, Alice! \u{1F60A}");
+}
+
 proptest! {
     #[test]
     fn greeting_service_prop(name in "[A-Za-z]{1,16}") {
         let service = GreetingService::new(EnglishGreeter);
         let expected = format!("Hello, {name}!");
+        prop_assert_eq!(service.send_greeting(&name), expected);
+    }
+
+    #[test]
+    fn greeting_service_with_formatter_prop(name in "[A-Za-z]{1,16}") {
+        let service = GreetingService::with_formatter(
+            EnglishGreeter,
+            Box::new(EmojiFormatter),
+        );
+        let expected = format!("Hello, {name}! \u{1F60A}");
         prop_assert_eq!(service.send_greeting(&name), expected);
     }
 }


### PR DESCRIPTION
## Summary
- create a `GreetingFormatter` trait with an `EmojiFormatter` implementation
- allow `GreetingService` to optionally use a formatter
- expose helpers module from the example crate
- test formatted greetings

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy, needless-borrow, etc.)*
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68838a9756fc832d9125b9d19ed477de