### PR TITLE
Format example crate

### DIFF
--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -7,11 +7,11 @@
 //! implementation and a [`GreetingService`] that composes a greeter to
 //! produce greeting messages.
 
+/// Miscellaneous helper utilities.
+pub mod helpers;
 /// Concrete implementations of the [`Greeter`] trait.
 pub mod implementations;
 /// Service layer types built on top of [`Greeter`] implementations.
 pub mod services;
-/// Miscellaneous helper utilities.
-pub mod helpers;
 /// Core abstractions used by this crate.
 pub mod traits;

--- a/Docs/examples/example_crate/src/services/greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/greeting_service.rs
@@ -19,10 +19,7 @@ impl<G: Greeter> GreetingService<G> {
     }
 
     /// Create a new service backed by the provided `greeter` and `formatter`.
-    pub fn with_formatter(
-        greeter: G,
-        formatter: Box<dyn GreetingFormatter>,
-    ) -> Self {
+    pub fn with_formatter(greeter: G, formatter: Box<dyn GreetingFormatter>) -> Self {
         Self {
             greeter,
             formatter: Some(formatter),

--- a/Docs/examples/example_crate/tests/greeting_service_tests.rs
+++ b/Docs/examples/example_crate/tests/greeting_service_tests.rs
@@ -1,5 +1,5 @@
-use example_crate::implementations::EnglishGreeter;
 use example_crate::helpers::EmojiFormatter;
+use example_crate::implementations::EnglishGreeter;
 use example_crate::services::GreetingService;
 use proptest::prelude::*;
 
@@ -11,10 +11,7 @@ fn greeting_service_returns_expected_greeting() {
 
 #[test]
 fn greeting_service_formats_output_with_emoji() {
-    let service = GreetingService::with_formatter(
-        EnglishGreeter,
-        Box::new(EmojiFormatter),
-    );
+    let service = GreetingService::with_formatter(EnglishGreeter, Box::new(EmojiFormatter));
     assert_eq!(service.send_greeting("Alice"), "Hello, Alice! \u{1F60A}");
 }
 


### PR DESCRIPTION
## Summary
- run `cargo fmt` over `example_crate`
- adjust imports and function formatting

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` in `Docs/examples/example_crate`
- `cargo test --all` in `Docs/examples/example_crate`

------
https://chatgpt.com/codex/tasks/task_e_6883927dbc8c832da9110242a60e8448