### PR TITLE
Fix intra-doc links for example crate

### DIFF
--- a/Docs/examples/example_crate/src/implementations/english_greeter.rs
+++ b/Docs/examples/example_crate/src/implementations/english_greeter.rs
@@ -1,4 +1,4 @@
-//! Implementation of [`Greeter`](crate::traits::Greeter) that outputs messages in English.
+//! Implementation of [`crate::traits::Greeter`] that outputs messages in English.
 
 use crate::traits::Greeter;
 

--- a/Docs/examples/example_crate/src/implementations/mod.rs
+++ b/Docs/examples/example_crate/src/implementations/mod.rs
@@ -1,4 +1,4 @@
-//! Collection of concrete [`Greeter`](crate::traits::Greeter) implementations.
+//! Collection of concrete [`crate::traits::Greeter`] implementations.
 
 pub mod english_greeter;
 

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -3,13 +3,13 @@
 
 //! Example crate demonstrating a basic layered architecture.
 //!
-//! This crate defines a [`Greeter`] trait along with a simple English
-//! implementation and a [`GreetingService`] that composes a greeter to
+//! This crate defines a [`crate::traits::Greeter`] trait along with a simple English
+//! implementation and a [`crate::services::GreetingService`] that composes a greeter to
 //! produce greeting messages.
 
-/// Concrete implementations of the [`Greeter`] trait.
+/// Concrete implementations of the [`crate::traits::Greeter`] trait.
 pub mod implementations;
-/// Service layer types built on top of [`Greeter`] implementations.
+/// Service layer types built on top of [`crate::traits::Greeter`] implementations.
 pub mod services;
 /// Miscellaneous helper utilities.
 pub mod helpers;

--- a/Docs/examples/example_crate/src/services/greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/greeting_service.rs
@@ -1,9 +1,9 @@
-//! Service implementations that make use of [`Greeter`](crate::traits::Greeter).
+//! Service implementations that make use of [`crate::traits::Greeter`].
 
 use crate::helpers::GreetingFormatter;
 use crate::traits::Greeter;
 
-/// Service that delegates greeting creation to a [`Greeter`].
+/// Service that delegates greeting creation to a [`crate::traits::Greeter`].
 pub struct GreetingService<G: Greeter> {
     greeter: G,
     formatter: Option<Box<dyn GreetingFormatter>>,

--- a/Docs/examples/example_crate/src/services/mod.rs
+++ b/Docs/examples/example_crate/src/services/mod.rs
@@ -1,4 +1,4 @@
-//! Service layer built on top of [`Greeter`](crate::traits::Greeter) implementations.
+//! Service layer built on top of [`crate::traits::Greeter`] implementations.
 
 pub mod greeting_service;
 


### PR DESCRIPTION
## Summary
- fix outdated intra-doc link syntax in example crate docs
- use fully qualified paths so links resolve correctly

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone_on_copy, needless_borrow, etc.)*
- `cargo test --all`
- `cargo doc --no-deps` in `Docs/examples/example_crate`

------
https://chatgpt.com/codex/tasks/task_e_68839283f9dc832da9986bc0797b4fcb