### PR TITLE
Add simple greeting service example

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -10,14 +10,24 @@ example_crate/
 ├── Cargo.toml
 ├── src/
 │   ├── lib.rs
-│   ├── traits/
-│   │   └── greeter.rs
+│   ├── helpers/
+│   │   ├── formatter.rs
+│   │   └── mod.rs
 │   ├── implementations/
-│   │   └── english_greeter.rs
-│   └── services/
-│       └── greeting_service.rs
+│   │   ├── english_greeter.rs
+│   │   └── mod.rs
+│   ├── services/
+│   │   ├── greeting/
+│   │   │   ├── builder.rs
+│   │   │   ├── mod.rs
+│   │   │   └── service.rs
+│   │   └── simple_greeting_service.rs
+│   └── traits/
+│       ├── greeter.rs
+│       └── mod.rs
 └── tests/
-    └── greeting_service_tests.rs
+    ├── greeting_service_tests.rs
+    └── simple_greeting_service_tests.rs
 ```
 
 `traits` defines abstractions (`Greeter`) that services depend on.

--- a/Docs/examples/example_crate/src/services/mod.rs
+++ b/Docs/examples/example_crate/src/services/mod.rs
@@ -2,5 +2,7 @@
 
 /// Types related to greeting messages.
 pub mod greeting;
+mod simple_greeting_service;
 
 pub use greeting::{GreetingService, GreetingServiceBuilder};
+pub use simple_greeting_service::SimpleGreetingService;

--- a/Docs/examples/example_crate/src/services/simple_greeting_service.rs
+++ b/Docs/examples/example_crate/src/services/simple_greeting_service.rs
@@ -1,0 +1,20 @@
+//! Simple greeting service without builder.
+
+use crate::traits::Greeter;
+
+/// Service that directly forwards greetings using a [`Greeter`].
+pub struct SimpleGreetingService<G: Greeter> {
+    greeter: G,
+}
+
+impl<G: Greeter> SimpleGreetingService<G> {
+    /// Create a new service backed by `greeter`.
+    pub fn new(greeter: G) -> Self {
+        Self { greeter }
+    }
+
+    /// Produce a greeting for `name` using the underlying `greeter`.
+    pub fn send_greeting(&self, name: &str) -> String {
+        self.greeter.greet(name)
+    }
+}

--- a/Docs/examples/example_crate/tests/simple_greeting_service_tests.rs
+++ b/Docs/examples/example_crate/tests/simple_greeting_service_tests.rs
@@ -1,0 +1,19 @@
+use example_crate::implementations::EnglishGreeter;
+use example_crate::services::SimpleGreetingService;
+use proptest::prelude::*;
+
+#[test]
+fn simple_service_returns_expected_greeting() {
+    let service = SimpleGreetingService::new(EnglishGreeter);
+    assert_eq!(service.send_greeting("Alice"), "Hello, Alice!");
+}
+
+proptest! {
+    #[test]
+    fn simple_service_prop(name in "[A-Za-z]{1,16}") {
+        let service = SimpleGreetingService::new(EnglishGreeter);
+        let expected = format!("Hello, {name}!");
+        prop_assert_eq!(service.send_greeting(&name), expected);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `SimpleGreetingService` without a builder
- expose the new service in the services module
- document project tree with the new service
- add unit tests for `SimpleGreetingService`

## Testing
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883b6cad448832d98ce40dc79f72c9f