### PR TITLE
Update example README docs

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -1,39 +1,36 @@
 # Example Crate
 
-This directory provides a minimal Rust crate named `example_crate` that
-illustrates how to organize code following SOLID principles.
-The layout keeps traits, implementations and services in separate
-folders so that components remain easy to test and extend.
+This directory contains `example_crate`, a small project showcasing
+how to structure Rust code according to the SOLID guidelines.  The
+crate uses a lightweight dependency injection container and keeps
+services, providers and processors in dedicated folders for easy
+testing and extensibility.
 
 ```
 example_crate/
 ├── Cargo.toml
 ├── src/
 │   ├── lib.rs
+│   ├── config.rs
+│   ├── container.rs
+│   ├── error.rs
 │   ├── helpers/
-│   │   ├── formatter.rs
-│   │   └── mod.rs
-│   ├── implementations/
-│   │   ├── english_greeter.rs
-│   │   └── mod.rs
-│   ├── services/
-│   │   ├── greeting/
-│   │   │   ├── builder.rs
-│   │   │   ├── mod.rs
-│   │   │   └── service.rs
-│   │   └── simple_greeting_service.rs
-│   └── traits/
-│       ├── greeter.rs
-│       └── mod.rs
+│   ├── models/
+│   ├── processors/
+│   ├── providers/
+│   └── services/
 └── tests/
-    ├── greeting_service_tests.rs
-    └── simple_greeting_service_tests.rs
+    ├── container_tests.rs
+    ├── helpers_tests.rs
+    ├── models_tests.rs
+    ├── processor_tests.rs
+    └── services_tests.rs
 ```
 
-`traits` defines abstractions (`Greeter`) that services depend on.
-Concrete implementations live in the `implementations` folder. Services
-compose these implementations through generic parameters, enabling loose
-coupling and straightforward unit testing.
+`services` expose traits and basic implementations. `providers` offer
+external data, while `processors` combine these pieces into higher level
+logic. Models and helper functions can be added as needed. This layout
+keeps units small and straightforward to test.
 
 Run the tests with:
 

--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -24,3 +24,10 @@ Any subset of these directories may be used. For instance, a crate might only de
 2. Implement the trait in its own module.
 3. Expose the trait and implementation in the corresponding `mod.rs`.
 4. Register the implementation in `container.rs` or provide a constructor so processors can use it.
+
+## Running Tests
+Execute the tests from the repository root with:
+
+```bash
+cargo test --manifest-path Docs/examples/example_crate/Cargo.toml
+```


### PR DESCRIPTION
## Summary
- update `Docs/examples/README.md` to display the actual folder layout of `example_crate`
- expand example crate README with testing instructions

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy, needless-borrow, etc.)*
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6884d0cc9ed4832dab7df2ded795f065