### PR TITLE
Add adapter example to reference crate

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -18,6 +18,7 @@ example_crate/
 │   ├── models/
 │   ├── processors/
 │   ├── providers/
+│   ├── adapters/
 │   └── services/
 └── tests/
     ├── container_tests.rs
@@ -29,7 +30,7 @@ example_crate/
 
 `services` expose traits and basic implementations. `providers` offer
 external data, while `processors` combine these pieces into higher level
-logic. Models and helper functions can be added as needed. This layout
+logic. `adapters` translate between interfaces. Models and helper functions can be added as needed. This layout
 keeps units small and straightforward to test.
 
 Run the tests with:

--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -13,11 +13,12 @@ src/
 ├── services/      # service traits and implementations
 ├── providers/     # provider traits and implementations
 ├── processors/    # logic consuming services
+├── adapters/      # traits adapting providers or services (optional)
 ├── helpers/       # small utility functions (optional)
 └── models/        # data models (optional)
 ```
 
-Any subset of these directories may be used. For instance, a crate might only define models or services.
+Any subset of these directories may be used. For instance, a crate might only define models or services. Adapters are optional wrappers that expose existing providers or services through a different interface.
 
 ## Adding a New Service
 1. Define a trait in `src/services` or `src/providers`.

--- a/Docs/examples/example_crate/src/adapters/mod.rs
+++ b/Docs/examples/example_crate/src/adapters/mod.rs
@@ -1,0 +1,6 @@
+//! Adapter module.
+//! Adapters converting between services or providers.
+
+mod uuid_string_adapter;
+
+pub use uuid_string_adapter::{DefaultUuidStringAdapter, UuidStringAdapter};

--- a/Docs/examples/example_crate/src/adapters/uuid_string_adapter.rs
+++ b/Docs/examples/example_crate/src/adapters/uuid_string_adapter.rs
@@ -1,0 +1,29 @@
+//! UUID string adapter example.
+//! Converts [`UuidProvider`] output into `String` values.
+
+use crate::error::Result;
+use crate::providers::UuidProvider;
+
+/// Adapter returning UUIDs as strings.
+pub trait UuidStringAdapter: Send + Sync {
+    /// Generate a UUID string.
+    fn uuid_string(&self) -> Result<String>;
+}
+
+/// Default adapter using a [`UuidProvider`].
+pub struct DefaultUuidStringAdapter<'a> {
+    provider: &'a dyn UuidProvider,
+}
+
+impl<'a> DefaultUuidStringAdapter<'a> {
+    /// Create a new adapter wrapping the given provider.
+    pub fn new(provider: &'a dyn UuidProvider) -> Self {
+        Self { provider }
+    }
+}
+
+impl<'a> UuidStringAdapter for DefaultUuidStringAdapter<'a> {
+    fn uuid_string(&self) -> Result<String> {
+        self.provider.uuid().map(|id| id.to_string())
+    }
+}

--- a/Docs/examples/example_crate/src/container.rs
+++ b/Docs/examples/example_crate/src/container.rs
@@ -29,4 +29,9 @@ impl Container {
     pub fn greeter_processor(&self) -> super::processors::GreeterProcessor {
         super::processors::GreeterProcessor::new(self.greeting.as_ref(), self.uuid.as_ref())
     }
+
+    /// Access the [`DefaultUuidStringAdapter`].
+    pub fn uuid_string_adapter(&self) -> super::adapters::DefaultUuidStringAdapter {
+        super::adapters::DefaultUuidStringAdapter::new(self.uuid.as_ref())
+    }
 }

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod container;
 pub mod error;
 pub mod processors;
+pub mod adapters;
 pub mod providers;
 pub mod services;
 pub mod helpers;

--- a/Docs/examples/example_crate/tests/adapters_tests.rs
+++ b/Docs/examples/example_crate/tests/adapters_tests.rs
@@ -1,0 +1,21 @@
+use example_crate::adapters::{DefaultUuidStringAdapter, UuidStringAdapter};
+use example_crate::providers::UuidProvider;
+use mockall::{mock, predicate::*};
+use uuid::Uuid;
+
+mock! {
+    Provider {}
+    impl UuidProvider for Provider {
+        fn uuid(&self) -> example_crate::error::Result<Uuid>;
+    }
+}
+
+#[test]
+fn adapter_converts_uuid_to_string() {
+    let mut provider = MockProvider::new();
+    provider.expect_uuid().returning(|| Ok(Uuid::nil()));
+
+    let adapter = DefaultUuidStringAdapter::new(&provider);
+    let out = adapter.uuid_string().unwrap();
+    assert_eq!(out, Uuid::nil().to_string());
+}

--- a/Docs/examples/example_crate/tests/container_tests.rs
+++ b/Docs/examples/example_crate/tests/container_tests.rs
@@ -1,4 +1,5 @@
 use example_crate::{config::Config, container::Container};
+use example_crate::adapters::UuidStringAdapter;
 
 #[test]
 fn container_provides_processor() {
@@ -6,4 +7,12 @@ fn container_provides_processor() {
     let p = c.greeter_processor();
     let msg = p.process("Bob").unwrap();
     assert!(msg.starts_with("Hello, Bob!"));
+}
+
+#[test]
+fn container_provides_adapter() {
+    let c = Container::new(Config::new("svc"));
+    let a = c.uuid_string_adapter();
+    let id = a.uuid_string().unwrap();
+    assert_eq!(id.parse::<uuid::Uuid>().unwrap().get_version_num(), 4);
 }


### PR DESCRIPTION
## Summary
- document the adapters folder in example crate
- implement `UuidStringAdapter` example
- expose the adapter through the container
- add adapter tests and update container tests

## Testing
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy and other warnings in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6884e7fe2968832dadd568ae3ed7001f