### PR TITLE
Improve example crate

### DIFF
--- a/Docs/examples/example_crate/Cargo.lock
+++ b/Docs/examples/example_crate/Cargo.lock
@@ -18,16 +18,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cfg-if"
@@ -54,13 +63,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "example_crate"
 version = "0.1.0"
 dependencies = [
  "mockall",
+ "proptest",
+ "serde",
  "thiserror",
+ "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "float-cmp"
@@ -70,6 +98,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
@@ -99,16 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,10 +145,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "log"
-version = "0.4.27"
+name = "linux-raw-sys"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
@@ -181,6 +205,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +259,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +298,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "regex"
@@ -264,10 +367,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustversion"
-version = "1.0.21"
+name = "rustix"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "syn"
@@ -289,6 +431,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -318,6 +473,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,8 +522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
- "js-sys",
- "wasm-bindgen",
+ "serde",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -344,62 +544,150 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
+name = "windows-sys"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasm-bindgen-shared",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+name = "windows-targets"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -408,4 +696,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/Docs/examples/example_crate/Cargo.toml
+++ b/Docs/examples/example_crate/Cargo.toml
@@ -5,7 +5,15 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"], default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 mockall = "0.11"
+proptest = "1"
+
+[features]
+default = []
+serde = ["dep:serde", "uuid/serde"]
+tracing = ["dep:tracing"]

--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -1,0 +1,21 @@
+# example_crate
+
+> A minimal, idiomatic, AI-friendly Rust crate demonstrating
+> service-oriented architecture with dependency injection.
+
+
+src/
+├── lib.rs          # Crate root & public re-exports
+├── config.rs       # Configuration structs
+├── container.rs    # Lightweight DI container
+├── error.rs        # Error type via `thiserror`
+├── services/       # Traits + impls for business logic
+├── providers/      # External data providers
+├── processors/     # High-level orchestration
+├── adapters/       # Interface adapters (e.g., tracing)
+├── helpers/        # Small utilities
+└── models/         # Plain data structures
+# User-provided custom instructions
+
+Make sure code is SOLID and is made with manageable architecture in mind.
+Implement unittests for each new feature added.

--- a/Docs/examples/example_crate/examples/simple.rs
+++ b/Docs/examples/example_crate/examples/simple.rs
@@ -1,0 +1,8 @@
+use example_crate::{config::Config, container::Container};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let container = Container::new(Config::new("demo"));
+    let processor = container.greeter_processor();
+    println!("{}", processor.process("Alice")?);
+    Ok(())
+}

--- a/Docs/examples/example_crate/src/adapters/uuid_string_adapter.rs
+++ b/Docs/examples/example_crate/src/adapters/uuid_string_adapter.rs
@@ -5,24 +5,63 @@ use crate::error::Result;
 use crate::providers::UuidProvider;
 
 /// Adapter returning UUIDs as strings.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::adapters::{DefaultUuidStringAdapter, UuidStringAdapter};
+/// use example_crate::providers::DefaultUuidProvider;
+/// let adapter = DefaultUuidStringAdapter::new(&DefaultUuidProvider);
+/// let _uuid = adapter.uuid_string().unwrap();
+/// ```
 pub trait UuidStringAdapter: Send + Sync {
     /// Generate a UUID string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::adapters::{DefaultUuidStringAdapter, UuidStringAdapter};
+    /// use example_crate::providers::DefaultUuidProvider;
+    /// let adapter = DefaultUuidStringAdapter::new(&DefaultUuidProvider);
+    /// let _ = adapter.uuid_string().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error from the underlying [`UuidProvider`].
     fn uuid_string(&self) -> Result<String>;
 }
 
 /// Default adapter using a [`UuidProvider`].
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::adapters::DefaultUuidStringAdapter;
+/// use example_crate::providers::DefaultUuidProvider;
+/// let adapter = DefaultUuidStringAdapter::new(&DefaultUuidProvider);
+/// ```
 pub struct DefaultUuidStringAdapter<'a> {
     provider: &'a dyn UuidProvider,
 }
 
 impl<'a> DefaultUuidStringAdapter<'a> {
     /// Create a new adapter wrapping the given provider.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::adapters::DefaultUuidStringAdapter;
+    /// use example_crate::providers::DefaultUuidProvider;
+    /// let _adapter = DefaultUuidStringAdapter::new(&DefaultUuidProvider);
+    /// ```
+    #[must_use]
     pub fn new(provider: &'a dyn UuidProvider) -> Self {
         Self { provider }
     }
 }
 
-impl<'a> UuidStringAdapter for DefaultUuidStringAdapter<'a> {
+impl UuidStringAdapter for DefaultUuidStringAdapter<'_> {
     fn uuid_string(&self) -> Result<String> {
         self.provider.uuid().map(|id| id.to_string())
     }

--- a/Docs/examples/example_crate/src/config.rs
+++ b/Docs/examples/example_crate/src/config.rs
@@ -1,5 +1,14 @@
 //! Shared configuration.
 /// Shared configuration for the application.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::config::Config;
+/// let c = Config::new("svc");
+/// assert_eq!(c.service_name, "svc");
+/// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Arbitrary service name.
@@ -8,6 +17,15 @@ pub struct Config {
 
 impl Config {
     /// Create a new config with `service_name`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::config::Config;
+    /// let cfg = Config::new("demo");
+    /// assert_eq!(cfg.service_name, "demo");
+    /// ```
+    #[must_use]
     pub fn new(service_name: impl Into<String>) -> Self {
         Self {
             service_name: service_name.into(),

--- a/Docs/examples/example_crate/src/container.rs
+++ b/Docs/examples/example_crate/src/container.rs
@@ -4,6 +4,14 @@ use crate::providers::{DefaultUuidProvider, UuidProvider};
 use crate::services::{DefaultGreetingService, GreetingService};
 
 /// Lightweight dependency injection container.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::{config::Config, container::Container};
+/// let c = Container::new(Config::new("svc"));
+/// assert_eq!(c.config().service_name, "svc");
+/// ```
 pub struct Container {
     config: Config,
     greeting: Box<dyn GreetingService>,
@@ -12,6 +20,14 @@ pub struct Container {
 
 impl Container {
     /// Build a new container with default implementations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::{config::Config, container::Container};
+    /// let _c = Container::new(Config::new("svc"));
+    /// ```
+    #[must_use]
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -21,16 +37,45 @@ impl Container {
     }
 
     /// Get the configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::{config::Config, container::Container};
+    /// let c = Container::new(Config::new("svc"));
+    /// assert_eq!(c.config().service_name, "svc");
+    /// ```
+    #[must_use]
     pub fn config(&self) -> &Config {
         &self.config
     }
 
     /// Access the [`GreeterProcessor`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::{config::Config, container::Container};
+    /// let c = Container::new(Config::new("svc"));
+    /// let processor = c.greeter_processor();
+    /// let _ = processor.process("Bob");
+    /// ```
+    #[must_use]
     pub fn greeter_processor(&self) -> super::processors::GreeterProcessor {
         super::processors::GreeterProcessor::new(self.greeting.as_ref(), self.uuid.as_ref())
     }
 
     /// Access the [`DefaultUuidStringAdapter`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::{adapters::UuidStringAdapter, config::Config, container::Container};
+    /// let c = Container::new(Config::new("svc"));
+    /// let adapter = c.uuid_string_adapter();
+    /// let _id = adapter.uuid_string().unwrap();
+    /// ```
+    #[must_use]
     pub fn uuid_string_adapter(&self) -> super::adapters::DefaultUuidStringAdapter {
         super::adapters::DefaultUuidStringAdapter::new(self.uuid.as_ref())
     }

--- a/Docs/examples/example_crate/src/error.rs
+++ b/Docs/examples/example_crate/src/error.rs
@@ -2,6 +2,16 @@
 use thiserror::Error;
 
 /// Crate-wide error type.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::error::{Error, Result};
+/// fn fail() -> Result<()> {
+///     Err(Error::Generic("oops".into()))
+/// }
+/// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Error)]
 pub enum Error {
     /// Generic failure.
@@ -9,4 +19,13 @@ pub enum Error {
     Generic(String),
 }
 /// Result type for the crate.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::error::{Error, Result};
+/// fn fallible() -> Result<()> {
+///     Err(Error::Generic("boom".into()))
+/// }
+/// ```
 pub type Result<T> = std::result::Result<T, Error>;

--- a/Docs/examples/example_crate/src/helpers/mod.rs
+++ b/Docs/examples/example_crate/src/helpers/mod.rs
@@ -1,6 +1,14 @@
 //! Helper utilities.
 
 /// Convert a string to uppercase.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::helpers::shout;
+/// assert_eq!(shout("hello"), "HELLO");
+/// ```
+#[must_use]
 pub fn shout(input: &str) -> String {
     input.to_uppercase()
 }

--- a/Docs/examples/example_crate/src/lib.rs
+++ b/Docs/examples/example_crate/src/lib.rs
@@ -1,15 +1,23 @@
 #![forbid(unsafe_code)]
-#![deny(missing_docs)]
+#![warn(missing_docs, clippy::all, clippy::pedantic)]
 
 //! Project-agnostic service-oriented template.
-//! Crate root.
+//!
+//! ```
+//! use example_crate::{config::Config, container::Container};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let container = Container::new(Config::new("demo"));
+//! let msg = container.greeter_processor().process("Bob")?;
+//! println!("{msg}");
+//! # Ok(()) }
+//! ```
 
+pub mod adapters;
 pub mod config;
 pub mod container;
 pub mod error;
-pub mod processors;
-pub mod adapters;
-pub mod providers;
-pub mod services;
 pub mod helpers;
 pub mod models;
+pub mod processors;
+pub mod providers;
+pub mod services;

--- a/Docs/examples/example_crate/src/models/mod.rs
+++ b/Docs/examples/example_crate/src/models/mod.rs
@@ -3,6 +3,16 @@
 use uuid::Uuid;
 
 /// Simple user model.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::models::User;
+/// use uuid::Uuid;
+/// let u = User::new(Uuid::nil(), "bob");
+/// assert_eq!(u.name, "bob");
+/// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct User {
     /// Unique identifier.
@@ -13,7 +23,19 @@ pub struct User {
 
 impl User {
     /// Create a new [`User`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::models::User;
+    /// use uuid::Uuid;
+    /// let u = User::new(Uuid::nil(), "alice");
+    /// assert_eq!(u.id, Uuid::nil());
+    /// ```
     pub fn new(id: Uuid, name: impl Into<String>) -> Self {
-        Self { id, name: name.into() }
+        Self {
+            id,
+            name: name.into(),
+        }
     }
 }

--- a/Docs/examples/example_crate/src/processors/greeter.rs
+++ b/Docs/examples/example_crate/src/processors/greeter.rs
@@ -4,21 +4,61 @@ use crate::providers::UuidProvider;
 use crate::services::GreetingService;
 
 /// Processor combining a [`GreetingService`] and [`UuidProvider`].
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::processors::GreeterProcessor;
+/// use example_crate::services::DefaultGreetingService;
+/// use example_crate::providers::DefaultUuidProvider;
+/// let proc = GreeterProcessor::new(&DefaultGreetingService, &DefaultUuidProvider);
+/// let out = proc.process("Bob").unwrap();
+/// assert!(out.starts_with("Hello, Bob!"));
+/// ```
 pub struct GreeterProcessor<'a> {
     greeting: &'a dyn GreetingService,
     uuid: &'a dyn UuidProvider,
 }
 
+#[allow(clippy::elidable_lifetime_names)]
 impl<'a> GreeterProcessor<'a> {
     /// Create a new processor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::processors::GreeterProcessor;
+    /// use example_crate::services::DefaultGreetingService;
+    /// use example_crate::providers::DefaultUuidProvider;
+    /// let _proc = GreeterProcessor::new(&DefaultGreetingService, &DefaultUuidProvider);
+    /// ```
+    #[must_use]
     pub fn new(greeting: &'a dyn GreetingService, uuid: &'a dyn UuidProvider) -> Self {
         Self { greeting, uuid }
     }
 
     /// Produce a greeting with a UUID suffix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::processors::GreeterProcessor;
+    /// use example_crate::services::DefaultGreetingService;
+    /// use example_crate::providers::DefaultUuidProvider;
+    /// let proc = GreeterProcessor::new(&DefaultGreetingService, &DefaultUuidProvider);
+    /// let msg = proc.process("Bob").unwrap();
+    /// assert!(msg.contains("Bob"));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from the [`GreetingService`] or [`UuidProvider`].
     pub fn process(&self, name: &str) -> Result<String> {
         let msg = self.greeting.greeting(name)?;
         let id = self.uuid.uuid()?;
-        Ok(format!("{msg} ({id})"))
+        let out = format!("{msg} ({id})");
+        #[cfg(feature = "tracing")]
+        tracing::info!(message = %out, "generated greeting");
+        Ok(out)
     }
 }

--- a/Docs/examples/example_crate/src/providers/uuid.rs
+++ b/Docs/examples/example_crate/src/providers/uuid.rs
@@ -3,12 +3,34 @@ use crate::error::Result;
 use uuid::Uuid;
 
 /// Supplies UUIDs.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::providers::{DefaultUuidProvider, UuidProvider};
+/// let provider = DefaultUuidProvider;
+/// let id = provider.uuid().unwrap();
+/// assert_eq!(id.get_version_num(), 4);
+/// ```
 pub trait UuidProvider: Send + Sync {
     /// Generate a new UUID.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from the provider implementation.
     fn uuid(&self) -> Result<Uuid>;
 }
 
 /// Default provider using `Uuid::new_v4`.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::providers::{DefaultUuidProvider, UuidProvider};
+/// let provider = DefaultUuidProvider;
+/// let _id = provider.uuid().unwrap();
+/// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DefaultUuidProvider;
 
 impl UuidProvider for DefaultUuidProvider {

--- a/Docs/examples/example_crate/src/services/greeting.rs
+++ b/Docs/examples/example_crate/src/services/greeting.rs
@@ -2,12 +2,42 @@
 use crate::error::Result;
 
 /// Produces greeting messages.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::services::{GreetingService, DefaultGreetingService};
+/// let svc = DefaultGreetingService;
+/// let msg = svc.greeting("Bob").unwrap();
+/// assert_eq!(msg, "Hello, Bob!");
+/// ```
 pub trait GreetingService: Send + Sync {
     /// Generate a greeting for `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use example_crate::services::{GreetingService, DefaultGreetingService};
+    /// let svc = DefaultGreetingService;
+    /// assert_eq!(svc.greeting("Bob").unwrap(), "Hello, Bob!");
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Propagates failures from the implementation.
     fn greeting(&self, name: &str) -> Result<String>;
 }
 
 /// Simple implementation returning `Hello, name!`.
+///
+/// # Examples
+///
+/// ```
+/// use example_crate::services::{GreetingService, DefaultGreetingService};
+/// let svc = DefaultGreetingService;
+/// assert_eq!(svc.greeting("Amy").unwrap(), "Hello, Amy!");
+/// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DefaultGreetingService;
 
 impl GreetingService for DefaultGreetingService {

--- a/Docs/examples/example_crate/tests/container_tests.rs
+++ b/Docs/examples/example_crate/tests/container_tests.rs
@@ -1,5 +1,5 @@
-use example_crate::{config::Config, container::Container};
 use example_crate::adapters::UuidStringAdapter;
+use example_crate::{config::Config, container::Container};
 
 #[test]
 fn container_provides_processor() {

--- a/Docs/examples/example_crate/tests/helpers_tests.rs
+++ b/Docs/examples/example_crate/tests/helpers_tests.rs
@@ -1,6 +1,14 @@
 use example_crate::helpers::shout;
+use proptest::prelude::*;
 
 #[test]
 fn shout_turns_uppercase() {
     assert_eq!(shout("Bob"), "BOB");
+}
+
+proptest! {
+    #[test]
+    fn shout_matches_uppercase(s in ".*") {
+        prop_assert_eq!(shout(&s), s.to_uppercase());
+    }
 }


### PR DESCRIPTION
## Summary
- modernize `example_crate` as the reference implementation
- document all public items with runnable examples
- add optional `serde`/`tracing` feature flags
- add a minimal usage example
- add property-based tests and logging

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --doc --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6885220f067c832db34e127db7050724