### PR TITLE
Add example crate unit tests

### DIFF
--- a/Docs/examples/example_crate/tests/container_tests.rs
+++ b/Docs/examples/example_crate/tests/container_tests.rs
@@ -1,0 +1,15 @@
+use example_crate::container::AppModule;
+use example_crate::services::Greeter;
+use example_crate::providers::NameProvider;
+use shaku::HasComponent;
+
+#[test]
+fn resolves_components() {
+    let module = AppModule::builder().build();
+    let greeter: std::sync::Arc<dyn Greeter> = module.resolve();
+    let name_provider: std::sync::Arc<dyn NameProvider> = module.resolve();
+
+    let greeting = greeter.greet("Rust").unwrap();
+    assert_eq!(greeting, "Hello, Rust!");
+    assert_eq!(name_provider.name().unwrap(), "World");
+}

--- a/Docs/examples/example_crate/tests/helpers_tests.rs
+++ b/Docs/examples/example_crate/tests/helpers_tests.rs
@@ -1,0 +1,7 @@
+use example_crate::helpers::string_helpers::capitalize;
+
+#[test]
+fn capitalize_basic() {
+    assert_eq!(capitalize("hello"), "Hello");
+    assert_eq!(capitalize("").as_str(), "");
+}

--- a/Docs/examples/example_crate/tests/processor_tests.rs
+++ b/Docs/examples/example_crate/tests/processor_tests.rs
@@ -1,0 +1,13 @@
+use example_crate::processors::HelloWorldProcessor;
+use example_crate::services::EnglishGreeter;
+use example_crate::providers::StaticNameProvider;
+use std::sync::Arc;
+
+#[test]
+fn hello_world_processor_runs() {
+    let greeter = Arc::new(EnglishGreeter);
+    let provider = Arc::new(StaticNameProvider::default());
+    let processor = HelloWorldProcessor::new(greeter, provider);
+    let greeting = processor.run().unwrap();
+    assert_eq!(greeting.message, "Hello, World!");
+}

--- a/Docs/examples/example_crate/tests/services_tests.rs
+++ b/Docs/examples/example_crate/tests/services_tests.rs
@@ -1,0 +1,16 @@
+use example_crate::services::{EnglishGreeter, Greeter};
+use example_crate::providers::{StaticNameProvider, NameProvider};
+
+#[test]
+fn english_greeter_greets() {
+    let g = EnglishGreeter;
+    let msg = g.greet("Rustacean").unwrap();
+    assert_eq!(msg, "Hello, Rustacean!");
+}
+
+#[test]
+fn static_name_provider_returns_world() {
+    let provider = StaticNameProvider::default();
+    let name = provider.name().unwrap();
+    assert_eq!(name, "World");
+}


### PR DESCRIPTION
## Summary
- add tests for dependency injection container
- test Greeter and NameProvider services
- verify HelloWorldProcessor output
- cover string helper capitalize

## Testing
- `cargo clippy --all-targets --manifest-path Docs/examples/example_crate/Cargo.toml -- -D warnings`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68867a2e9ac8832d863618968a226255