### PR TITLE
Update example crate README

### DIFF
--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -2,16 +2,30 @@
 
 A tiny service oriented crate demonstrating compile-time dependency injection
 with [`shaku`](https://crates.io/crates/shaku). It exposes a greeting workflow
-and includes optional logging and a small configuration loader.
+and includes a configuration loader. Optional features enable tracing based
+logging and `serde` serialization for the models.
 
 ## Quick start
 
 ```bash
 # build and run tests
 cargo test --manifest-path Docs/examples/example_crate/Cargo.toml
-# run the example
-cargo run --example demo --manifest-path Docs/examples/example_crate/Cargo.toml
+# run the example with logging enabled
+GREETING_PREFIX=Hi \
+  cargo run --example demo \
+  --manifest-path Docs/examples/example_crate/Cargo.toml \
+  --features logging
 ```
+
+## Features
+
+- `logging` – enables tracing output and the `demo` example.
+- `serde` – adds serialization support for models.
+
+## Configuration
+
+`Config::load` reads the optional `GREETING_PREFIX` environment variable. If the
+variable is unset, the prefix defaults to `"Hello"`.
 
 ## Architecture
 
@@ -40,6 +54,7 @@ cargo run --example demo --manifest-path Docs/examples/example_crate/Cargo.toml
 ```
 
 All public types include thorough documentation with runnable examples.
+Unit and property-based tests live under `tests/`.
 
 ## Adding a new service
 


### PR DESCRIPTION
## Summary
- refine `example_crate` README to match the current code
- document logging and serde features and configuration
- show how to run the demo with logging

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `rust-bomberman` due to clippy warnings)*
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_688695b92588832db63274a02165f256