### PR TITLE
Align example crate docs and modules

### DIFF
--- a/Docs/examples/README.md
+++ b/Docs/examples/README.md
@@ -16,18 +16,16 @@ example_crate/
 │   ├── services/
 │   ├── providers/
 │   ├── processors/
-│   ├── adapters/
 │   ├── helpers/
 │   └── models/
 └── tests/
-    ├── container_tests.rs
-    ├── helpers_tests.rs
+    ├── config_tests.rs
+    ├── integration_test.rs
     ├── models_tests.rs
-    ├── processor_tests.rs
-    └── services_tests.rs
+    └── proptests.rs
 ```
 
-Services expose traits and baseline implementations. Providers offer external data while processors combine these pieces into higher level logic. Adapters translate between interfaces when needed. Helpers and models host utilities and data structures. This layout keeps units small and straightforward to test.
+Services expose traits and baseline implementations. Providers offer external data while processors combine these pieces into higher level logic. Helpers and models host utilities and data structures. This layout keeps units small and straightforward to test.
 
 ## Adding a New Service
 1. Define a trait in `src/services` or `src/providers`.


### PR DESCRIPTION
## Summary
- remove adapters module and placeholder tests
- update example README to reflect crate's actual file layout

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy and other warnings in main crate)*
- `cargo test --all`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_688675dfb6a4832daa9237bfbe12a4f2