### PR TITLE
Update README with backlog and feature links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ cargo test --all
 Detailed design notes live in the `Docs/` directory. A fully documented example
 crate demonstrating SOLID organization and compile-time dependency injection is
 available under `Docs/examples`. See `Docs/examples/README.md` for details.
+
+For an overview of planned work consult the [project backlog](Docs/backlog/backlog.md).
+Progress on implemented features is tracked in [Docs/completed/features.md](Docs/completed/features.md).


### PR DESCRIPTION
## Summary
- point to backlog and completed docs in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clone-on-copy and other lints)*
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68874aefc9a8832da29207036172debb