### PR TITLE
Enhance example crate

### DIFF
--- a/Docs/examples/example_crate/Cargo.lock
+++ b/Docs/examples/example_crate/Cargo.lock
@@ -57,6 +57,7 @@ version = "0.2.0"
 dependencies = [
  "proptest",
  "serde",
+ "serde_json",
  "shaku",
  "thiserror",
  "tracing",
@@ -88,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +117,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nu-ansi-term"
@@ -277,6 +290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +313,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Docs/examples/example_crate/Cargo.toml
+++ b/Docs/examples/example_crate/Cargo.toml
@@ -2,6 +2,17 @@
 name = "example_crate"
 version = "0.2.0"
 edition = "2021"
+authors = ["Example Maintainer <maintainer@example.com>"]
+description = "Reference service-oriented crate for AI agents"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/harmenhilversalten/bomberman-rust-tournament"
+repository = "https://github.com/harmenhilversalten/bomberman-rust-tournament"
+keywords = ["dependency-injection", "template", "example", "services", "di"]
+categories = ["development-tools", "game-engines"]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 thiserror = "1"
@@ -12,11 +23,13 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest = "1"
+serde_json = "1"
 
 [features]
 default = []
 serde = ["dep:serde"]
 logging = ["dep:tracing", "dep:tracing-subscriber"]
+async = []
 
 [[bin]]
 name = "demo"

--- a/Docs/examples/example_crate/README.md
+++ b/Docs/examples/example_crate/README.md
@@ -20,7 +20,8 @@ GREETING_PREFIX=Hi \
 ## Features
 
  - `logging` – enables tracing output and the demo binary.
-- `serde` – adds serialization support for models.
+ - `serde` – adds serialization support for models and config.
+ - `async` – reserved for future asynchronous examples.
 
 ## Configuration
 
@@ -55,6 +56,11 @@ variable is unset, the prefix defaults to `"Hello"`.
 
 All public types include thorough documentation with runnable examples.
 Unit and property-based tests live under `tests/`.
+
+## Helpers
+
+Utility functions for strings are available under `helpers::string_helpers` and
+include capitalization, truncation and alphanumeric validation utilities.
 
 ## Adding a new service
 

--- a/Docs/examples/example_crate/src/bin/demo.rs
+++ b/Docs/examples/example_crate/src/bin/demo.rs
@@ -4,9 +4,19 @@ use shaku::HasComponent;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn main() -> Result<()> {
-    let subscriber = FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber).expect("set subscriber");
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    #[cfg(feature = "logging")]
+    {
+        let subscriber = FmtSubscriber::new();
+        tracing::subscriber::set_global_default(subscriber).expect("set subscriber");
+    }
 
     let cfg = Config::load()?;
     let module = AppModule::builder().build();

--- a/Docs/examples/example_crate/src/config.rs
+++ b/Docs/examples/example_crate/src/config.rs
@@ -9,28 +9,64 @@
 //! let cfg = Config::load().unwrap();
 //! assert_eq!(cfg.prefix, "Hi");
 //! ```
+//!
+//! ```
+//! # #[cfg(feature = "serde")] {
+//! use example_crate::config::Config;
+//! let cfg = Config { prefix: "Hey".into() };
+//! let s = serde_json::to_string(&cfg).unwrap();
+//! let back: Config = serde_json::from_str(&s).unwrap();
+//! assert_eq!(back.prefix, "Hey");
+//! # }
+//! ```
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use std::env;
 
-/// Application configuration.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Application configuration.
 pub struct Config {
     /// Prefix used for greetings.
     pub prefix: String,
 }
 
 impl Config {
+    /// Validate the provided `prefix` string.
+    ///
+    /// ```
+    /// use example_crate::config::Config;
+    /// assert!(Config::validate_prefix("Hi").is_ok());
+    /// assert!(Config::validate_prefix("").is_err());
+    /// ```
+    pub fn validate_prefix(prefix: &str) -> Result<()> {
+        const MAX_PREFIX_LEN: usize = 32;
+        if prefix.trim().is_empty() {
+            Err(Error::Config("GREETING_PREFIX is empty".into()))
+        } else if prefix.len() > MAX_PREFIX_LEN {
+            Err(Error::Config(format!(
+                "GREETING_PREFIX must be at most {MAX_PREFIX_LEN} characters"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Load configuration from environment variables.
+    ///
+    /// # Errors
+    /// Returns an [`Error::Config`] when the prefix is invalid.
+    ///
+    /// ```
+    /// use example_crate::config::Config;
+    /// std::env::set_var("GREETING_PREFIX", "Hi");
+    /// let cfg = Config::load().unwrap();
+    /// assert_eq!(cfg.prefix, "Hi");
+    /// ```
     pub fn load() -> Result<Self> {
         let prefix = env::var("GREETING_PREFIX").unwrap_or_else(|_| "Hello".to_owned());
-        if prefix.trim().is_empty() {
-            Err(crate::error::Error::Config(
-                "GREETING_PREFIX is empty".into(),
-            ))
-        } else {
-            Ok(Self { prefix })
-        }
+        Self::validate_prefix(&prefix)?;
+        Ok(Self { prefix })
     }
 }
 
@@ -54,5 +90,12 @@ mod tests {
         std::env::set_var("GREETING_PREFIX", "Yo");
         let cfg = Config::load().unwrap();
         assert_eq!(cfg.prefix, "Yo");
+    }
+
+    #[test]
+    fn validate_prefix_rejects_bad_values() {
+        assert!(Config::validate_prefix("").is_err());
+        let long = "x".repeat(40);
+        assert!(Config::validate_prefix(&long).is_err());
     }
 }

--- a/Docs/examples/example_crate/src/helpers/string_helpers.rs
+++ b/Docs/examples/example_crate/src/helpers/string_helpers.rs
@@ -17,3 +17,26 @@ pub fn capitalize(input: &str) -> String {
         Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
 }
+
+/// Truncate `s` to at most `max_len` characters.
+///
+/// ```
+/// use example_crate::helpers::string_helpers::truncate;
+/// assert_eq!(truncate("abcdef", 3), "abc");
+/// ```
+#[must_use]
+pub fn truncate(s: &str, max_len: usize) -> String {
+    s.chars().take(max_len).collect()
+}
+
+/// Returns `true` if `s` contains only alphanumeric characters.
+///
+/// ```
+/// use example_crate::helpers::string_helpers::is_alphanumeric;
+/// assert!(is_alphanumeric("abc123"));
+/// assert!(!is_alphanumeric("hi!"));
+/// ```
+#[must_use]
+pub fn is_alphanumeric(s: &str) -> bool {
+    s.chars().all(|c| c.is_ascii_alphanumeric())
+}

--- a/Docs/examples/example_crate/tests/config_tests.rs
+++ b/Docs/examples/example_crate/tests/config_tests.rs
@@ -9,3 +9,11 @@ fn load_default_and_env() {
     let cfg = Config::load().unwrap();
     assert_eq!(cfg.prefix, "Hey");
 }
+
+#[test]
+fn invalid_prefix_errors() {
+    std::env::set_var("GREETING_PREFIX", "");
+    assert!(Config::load().is_err());
+    std::env::set_var("GREETING_PREFIX", "x".repeat(40));
+    assert!(Config::load().is_err());
+}

--- a/Docs/examples/example_crate/tests/helpers_tests.rs
+++ b/Docs/examples/example_crate/tests/helpers_tests.rs
@@ -1,7 +1,19 @@
-use example_crate::helpers::string_helpers::capitalize;
+use example_crate::helpers::string_helpers::{capitalize, is_alphanumeric, truncate};
 
 #[test]
 fn capitalize_basic() {
     assert_eq!(capitalize("hello"), "Hello");
     assert_eq!(capitalize("").as_str(), "");
+}
+
+#[test]
+fn truncate_shortens_string() {
+    assert_eq!(truncate("abcdef", 4), "abcd");
+    assert_eq!(truncate("abc", 10), "abc");
+}
+
+#[test]
+fn alphanumeric_check() {
+    assert!(is_alphanumeric("abc123"));
+    assert!(!is_alphanumeric("abc!"));
 }

--- a/Docs/examples/example_crate/tests/proptests.rs
+++ b/Docs/examples/example_crate/tests/proptests.rs
@@ -1,4 +1,5 @@
 use example_crate::models::Greeting;
+use example_crate::helpers::string_helpers::truncate;
 use proptest::prelude::*;
 
 proptest! {
@@ -6,5 +7,13 @@ proptest! {
     fn greeting_roundtrip(s in ".*") {
         let g = Greeting::new(&s);
         prop_assert_eq!(g.message, s);
+    }
+}
+
+proptest! {
+    #[test]
+    fn truncate_never_exceeds_len(s in ".*", max in 0usize..20) {
+        let out = truncate(&s, max);
+        prop_assert!(out.chars().count() <= max);
     }
 }


### PR DESCRIPTION
## Summary
- enrich Cargo metadata and add new async feature
- expand config with validation and serde examples
- add truncation and alphanumeric helpers with docs
- implement improved demo binary with graceful error handling
- provide additional tests including proptests

## Testing
- `cargo clippy --manifest-path Docs/examples/example_crate/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path Docs/examples/example_crate/Cargo.toml --all-features`


------
https://chatgpt.com/codex/tasks/task_e_688a72dff1a4832db866e1e3055ad974