### PR TITLE
Add state serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +146,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -314,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +358,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -380,7 +413,10 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "crossbeam-epoch",
+ "serde",
+ "serde_json",
  "tokio",
  "triomphe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ petgraph = "0.6"
 triomphe = "0.1"
 anyhow = "1.0"
 tch = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+bincode = "1"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -23,3 +23,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Workspace restructure with skeleton crates ([Backlog #1](../backlog/backlog.md#1-restructure-into-workspace)).
 - Core state crate structures ([Backlog #2](../backlog/backlog.md#2-state-crate-%E2%80%93-core-structures)).
 - Snapshot layer with immutable views ([Backlog #3](../backlog/backlog.md#3-state-crate-%E2%80%93-snapshot-layer)).
+- State serialization supporting binary and JSON formats ([Backlog #4](../backlog/backlog.md#4-state-crate-%E2%80%93-serialization)).

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 crossbeam-epoch = { workspace = true }
 triomphe = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+bincode = { workspace = true }

--- a/crates/state/src/components/agent.rs
+++ b/crates/state/src/components/agent.rs
@@ -1,7 +1,9 @@
 //! Representation of an agent playing the game.
 
+use serde::{Deserialize, Serialize};
+
 /// Current state for a single agent.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AgentState {
     /// Unique agent identifier.
     pub id: usize,

--- a/crates/state/src/components/bomb.rs
+++ b/crates/state/src/components/bomb.rs
@@ -1,7 +1,9 @@
 //! Bomb component with timing and properties.
 
+use serde::{Deserialize, Serialize};
+
 /// Live bomb placed on the grid.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Bomb {
     /// Identifier of the owner agent.
     pub owner: usize,

--- a/crates/state/src/grid/game_grid.rs
+++ b/crates/state/src/grid/game_grid.rs
@@ -51,6 +51,59 @@ impl GameGrid {
         }
     }
 
+    /// Constructs a grid from raw parts used during deserialization.
+    pub(crate) fn from_parts(
+        width: usize,
+        height: usize,
+        tiles: Vec<Tile>,
+        bombs: Vec<Bomb>,
+        agents: Vec<AgentState>,
+        version: u64,
+    ) -> Self {
+        let (tx, _rx) = watch::channel(GridDelta::None);
+        let inner = SnapshotInner::new(
+            Arc::<[Tile]>::from(tiles.clone()),
+            Arc::<[Bomb]>::from(bombs.clone()),
+            Arc::<[AgentState]>::from(agents.clone()),
+            version,
+        );
+        Self {
+            width,
+            height,
+            tiles,
+            bombs,
+            agents,
+            version: AtomicU64::new(version),
+            snapshot: Atomic::new(inner),
+            delta_tx: tx,
+        }
+    }
+
+    /// Width of the grid.
+    pub(crate) fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Height of the grid.
+    pub(crate) fn height(&self) -> usize {
+        self.height
+    }
+
+    /// All tiles in the grid.
+    pub(crate) fn tiles(&self) -> &[Tile] {
+        &self.tiles
+    }
+
+    /// All bombs currently in the grid.
+    pub(crate) fn bombs(&self) -> &[Bomb] {
+        &self.bombs
+    }
+
+    /// All agents currently in the grid.
+    pub(crate) fn agents(&self) -> &[AgentState] {
+        &self.agents
+    }
+
     fn index(&self, x: usize, y: usize) -> usize {
         y * self.width + x
     }

--- a/crates/state/src/grid/tile.rs
+++ b/crates/state/src/grid/tile.rs
@@ -1,7 +1,9 @@
 //! Tile representation for the game grid.
 
+use serde::{Deserialize, Serialize};
+
 /// Different types of grid tiles.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Tile {
     /// Empty walkable tile
     Empty,

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -5,10 +5,13 @@
 
 pub mod components;
 pub mod grid;
+/// Serialization utilities for the game state.
+pub mod serialization;
 pub mod state;
 
 pub use components::{AgentState, Bomb};
 pub use grid::{GameGrid, Tile};
+pub use serialization::{Format, SerializationError, decoder, encoder};
 pub use state::{GameState, SnapshotView};
 
 /// Initializes the crate and returns a greeting.

--- a/crates/state/src/serialization/decoder.rs
+++ b/crates/state/src/serialization/decoder.rs
@@ -1,0 +1,12 @@
+use crate::state::GameState;
+
+use super::{Format, SerializableState, SerializationError};
+
+/// Decode bytes into a game state using the specified format.
+pub fn decode(bytes: &[u8], format: Format) -> Result<GameState, SerializationError> {
+    let data: SerializableState = match format {
+        Format::Binary => bincode::deserialize(bytes).map_err(SerializationError::Binary)?,
+        Format::Json => serde_json::from_slice(bytes).map_err(SerializationError::Json)?,
+    };
+    Ok(GameState::from(data))
+}

--- a/crates/state/src/serialization/encoder.rs
+++ b/crates/state/src/serialization/encoder.rs
@@ -1,0 +1,12 @@
+use crate::state::GameState;
+
+use super::{Format, SerializableState, SerializationError};
+
+/// Encode the provided game state into the selected format.
+pub fn encode(state: &GameState, format: Format) -> Result<Vec<u8>, SerializationError> {
+    let data = SerializableState::from(state);
+    match format {
+        Format::Binary => bincode::serialize(&data).map_err(SerializationError::Binary),
+        Format::Json => serde_json::to_vec(&data).map_err(SerializationError::Json),
+    }
+}

--- a/crates/state/src/serialization/mod.rs
+++ b/crates/state/src/serialization/mod.rs
@@ -1,0 +1,107 @@
+//! Serialization and deserialization of the game state.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    components::{AgentState, Bomb},
+    grid::{GameGrid, Tile},
+    state::GameState,
+};
+
+/// Supported serialization formats.
+#[derive(Debug, Clone, Copy)]
+pub enum Format {
+    /// Binary format using bincode.
+    Binary,
+    /// JSON text format.
+    Json,
+}
+
+/// Errors that can occur during serialization or deserialization.
+#[derive(Debug)]
+pub enum SerializationError {
+    /// Error with binary encoding/decoding.
+    Binary(bincode::Error),
+    /// Error with JSON encoding/decoding.
+    Json(serde_json::Error),
+}
+
+impl From<bincode::Error> for SerializationError {
+    fn from(err: bincode::Error) -> Self {
+        SerializationError::Binary(err)
+    }
+}
+
+impl From<serde_json::Error> for SerializationError {
+    fn from(err: serde_json::Error) -> Self {
+        SerializationError::Json(err)
+    }
+}
+
+/// Internal representation of the game state for serialization.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct SerializableState {
+    width: usize,
+    height: usize,
+    tiles: Vec<Tile>,
+    bombs: Vec<Bomb>,
+    agents: Vec<AgentState>,
+    version: u64,
+}
+
+impl From<&GameState> for SerializableState {
+    fn from(state: &GameState) -> Self {
+        Self {
+            width: state.grid.width(),
+            height: state.grid.height(),
+            tiles: state.grid.tiles().to_vec(),
+            bombs: state.grid.bombs().to_vec(),
+            agents: state.grid.agents().to_vec(),
+            version: state.grid.version(),
+        }
+    }
+}
+
+impl From<SerializableState> for GameState {
+    fn from(s: SerializableState) -> Self {
+        let grid = GameGrid::from_parts(s.width, s.height, s.tiles, s.bombs, s.agents, s.version);
+        GameState { grid }
+    }
+}
+
+/// Utilities for decoding state.
+pub mod decoder;
+/// Utilities for encoding state.
+pub mod encoder;
+
+#[cfg(test)]
+mod tests {
+    use super::{Format, decoder, encoder};
+    use crate::{
+        components::{AgentState, Bomb},
+        grid::{GridDelta, Tile},
+        state::GameState,
+    };
+
+    #[test]
+    fn round_trip_binary_and_json() {
+        let mut state = GameState::new(2, 2);
+        state.apply_delta(GridDelta::SetTile {
+            x: 0,
+            y: 1,
+            tile: Tile::Wall,
+        });
+        state.apply_delta(GridDelta::AddBomb(Bomb::new(1, (0, 0), 3, 1)));
+        state.apply_delta(GridDelta::AddAgent(AgentState::new(1, (1, 1))));
+
+        for format in [Format::Binary, Format::Json] {
+            let bytes = encoder::encode(&state, format).expect("encode");
+            let decoded = decoder::decode(&bytes, format).expect("decode");
+            assert_eq!(decoded.grid.width(), 2);
+            assert_eq!(decoded.grid.height(), 2);
+            assert_eq!(decoded.grid.tile(0, 1), Some(Tile::Wall));
+            assert_eq!(decoded.grid.bombs().len(), 1);
+            assert_eq!(decoded.grid.agents().len(), 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add binary and JSON serialization utilities for GameState
- expose GameGrid helpers to support encoding/decoding
- document completion of state serialization backlog item

## Testing
- `cargo clippy -p state --all-targets -- -D warnings`
- `cargo test -p state`


------
https://chatgpt.com/codex/tasks/task_e_688daf42708c832db28a2c5b22d25a0a