### PR TITLE
feat(engine): add core loop with delta broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,8 @@ version = "0.1.0"
 dependencies = [
  "num_cpus",
  "rand",
+ "state",
+ "tokio",
 ]
 
 [[package]]

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -24,3 +24,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Core state crate structures ([Backlog #2](../backlog/backlog.md#2-state-crate-%E2%80%93-core-structures)).
 - Snapshot layer with immutable views ([Backlog #3](../backlog/backlog.md#3-state-crate-%E2%80%93-snapshot-layer)).
 - State serialization supporting binary and JSON formats ([Backlog #4](../backlog/backlog.md#4-state-crate-%E2%80%93-serialization)).
+- Engine core loop with delta broadcasting ([Backlog #5](../backlog/backlog.md#5-engine-crate-%E2%80%93-core-loop)).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Bomberman Using Rust Project
 
-This repository hosts a small Bomberman inspired tournament runner written in Rust.  
+This repository hosts a small Bomberman inspired tournament runner written in Rust.
 It serves as a playground to explore the language while incrementally adopting the architecture described in [`Docs/architecture`](Docs/Architecture.md).
 
 ## Running
 
 The project is organized as a Cargo workspace. The main engine crate lives in `crates/engine`.
+That crate exposes an `Engine` struct managing the shared `GameGrid` and broadcasting `GridDelta` events each tick.
 
 Build and launch a tournament with the default settings:
 
@@ -23,5 +24,5 @@ cargo test --all
 
 Detailed design notes live in the `Docs/` directory. A fully documented example crate demonstrating SOLID organization and compile-time dependency injection is available under `Docs/examples`. See `Docs/examples/README.md` for details.
 
-For an overview of planned work consult the [project backlog](Docs/backlog/backlog.md).  
+For an overview of planned work consult the [project backlog](Docs/backlog/backlog.md).
 Progress on implemented features is tracked in [Docs/completed/features.md](Docs/completed/features.md).

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2024"
 [dependencies]
 rand = "0.9.1"
 num_cpus = "1.13"
+state = { path = "../state" }
+tokio = { workspace = true, features = ["sync"] }

--- a/crates/engine/src/engine/game_engine.rs
+++ b/crates/engine/src/engine/game_engine.rs
@@ -1,0 +1,68 @@
+use std::sync::{Arc, RwLock};
+
+use state::{GameGrid, Tile, grid::GridDelta};
+use tokio::sync::watch;
+
+/// Core game engine advancing the simulation and broadcasting changes.
+pub struct Engine {
+    grid: Arc<RwLock<GameGrid>>,
+    delta_tx: watch::Sender<GridDelta>,
+    toggle: bool,
+}
+
+impl Engine {
+    /// Creates a new engine with a square grid of the given size.
+    pub fn new(size: usize) -> (Self, watch::Receiver<GridDelta>) {
+        let grid = GameGrid::new(size, size);
+        let (tx, rx) = watch::channel(GridDelta::None);
+        (
+            Self {
+                grid: Arc::new(RwLock::new(grid)),
+                delta_tx: tx,
+                toggle: false,
+            },
+            rx,
+        )
+    }
+
+    /// Advances the game by a single tick.
+    ///
+    /// This demo implementation simply toggles the tile at (0,0) between
+    /// `Tile::Empty` and `Tile::Wall` and broadcasts the resulting delta.
+    pub fn tick(&mut self) {
+        let delta = {
+            let mut grid = self.grid.write().expect("grid lock poisoned");
+            let tile = if self.toggle { Tile::Empty } else { Tile::Wall };
+            self.toggle = !self.toggle;
+            let delta = GridDelta::SetTile { x: 0, y: 0, tile };
+            grid.apply_delta(delta.clone());
+            delta
+        };
+        let _ = self.delta_tx.send(delta);
+    }
+
+    /// Access the shared game grid.
+    pub fn grid(&self) -> Arc<RwLock<GameGrid>> {
+        Arc::clone(&self.grid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_broadcasts_delta() {
+        let (mut engine, mut rx) = Engine::new(1);
+        assert_eq!(*rx.borrow(), GridDelta::None);
+        engine.tick();
+        assert_eq!(
+            rx.borrow_and_update().clone(),
+            GridDelta::SetTile {
+                x: 0,
+                y: 0,
+                tile: Tile::Wall
+            }
+        );
+    }
+}

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -1,0 +1,3 @@
+pub mod game_engine;
+
+pub use game_engine::Engine;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,7 +1,11 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::all)]
+
 pub mod bot;
 pub mod coord;
+pub mod engine;
 pub mod game;
 pub mod map;
 pub mod shrink;
+
+pub use engine::Engine;


### PR DESCRIPTION
## Summary
- implement `Engine` with shared `GameGrid` and delta channel
- toggle a tile each tick and broadcast `GridDelta`
- document completed backlog item and update README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688db6e31714832d821ac881ee8ab003