### PR TITLE
feat(engine): add replay and determinism

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -27,3 +27,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Engine core loop with delta broadcasting ([Backlog #5](../backlog/backlog.md#5-engine-crate-%E2%80%93-core-loop)).
 - Engine scheduler supporting parallel task execution ([Backlog #6](../backlog/backlog.md#6-engine-crate-%E2%80%93-scheduler)).
 - Engine systems for movement, bombs, explosions, powerups and players ([Backlog #7](../backlog/backlog.md#7-engine-crate-%E2%80%93-system-modules)).
+- Replay recording and determinism checks ([Backlog #8](../backlog/backlog.md#8-engine-crate-%E2%80%93-replay-and-determinism)).

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -7,7 +7,9 @@ pub mod engine;
 pub mod game;
 pub mod map;
 pub mod shrink;
+pub mod simulation;
 pub mod systems;
 
 pub use engine::{Engine, TaskScheduler};
+pub use simulation::{DeterminismChecker, Replay, ReplayRecorder};
 pub use systems::System;

--- a/crates/engine/src/simulation/determinism.rs
+++ b/crates/engine/src/simulation/determinism.rs
@@ -1,0 +1,56 @@
+use state::GameGrid;
+
+/// Computes a deterministic hash of the game grid.
+pub fn hash_grid(grid: &GameGrid) -> u64 {
+    let snapshot = grid.snapshot();
+    let mut hash = 0u64;
+    for tile in snapshot.tiles() {
+        hash = hash.wrapping_mul(31).wrapping_add(tile.to_u8() as u64);
+    }
+    for bomb in snapshot.bombs() {
+        hash = hash
+            .wrapping_mul(37)
+            .wrapping_add(bomb.owner as u64)
+            .wrapping_add(bomb.position.0 as u64)
+            .wrapping_add(bomb.position.1 as u64)
+            .wrapping_add(bomb.timer as u64)
+            .wrapping_add(bomb.power as u64)
+            .wrapping_add(if bomb.pierce { 1 } else { 0 })
+            .wrapping_add(if bomb.remote { 1 } else { 0 } << 1);
+    }
+    for agent in snapshot.agents() {
+        hash = hash
+            .wrapping_mul(41)
+            .wrapping_add(agent.id as u64)
+            .wrapping_add(agent.position.0 as u64)
+            .wrapping_add(agent.position.1 as u64)
+            .wrapping_add(agent.bombs_left as u64)
+            .wrapping_add(agent.power as u64);
+    }
+    hash
+}
+
+/// Tracks hashes for determinism verification.
+#[derive(Default)]
+pub struct DeterminismChecker {
+    hashes: Vec<u64>,
+}
+
+impl DeterminismChecker {
+    /// Create a new checker.
+    pub fn new() -> Self {
+        Self { hashes: Vec::new() }
+    }
+
+    /// Record the current grid state and return its hash.
+    pub fn record(&mut self, grid: &GameGrid) -> u64 {
+        let hash = hash_grid(grid);
+        self.hashes.push(hash);
+        hash
+    }
+
+    /// Access recorded hashes.
+    pub fn hashes(&self) -> &[u64] {
+        &self.hashes
+    }
+}

--- a/crates/engine/src/simulation/mod.rs
+++ b/crates/engine/src/simulation/mod.rs
@@ -1,0 +1,26 @@
+pub mod determinism;
+pub mod replay;
+
+pub use determinism::{DeterminismChecker, hash_grid};
+pub use replay::{Replay, ReplayRecorder};
+
+#[cfg(test)]
+mod tests {
+    use crate::{engine::Engine, systems::MovementSystem};
+
+    #[test]
+    fn replay_reproduces_state() {
+        let (mut engine, _rx) = Engine::new(1);
+        engine.add_system(Box::new(MovementSystem::new()));
+        engine.start_replay_recording();
+        for _ in 0..3 {
+            engine.tick();
+        }
+        let replay = engine.stop_replay_recording();
+        let recorded_hashes = engine.determinism_hashes().to_vec();
+
+        let (mut engine2, _rx2) = Engine::new(1);
+        engine2.load_replay(&replay);
+        assert_eq!(engine2.determinism_hashes(), recorded_hashes.as_slice());
+    }
+}

--- a/crates/engine/src/simulation/replay.rs
+++ b/crates/engine/src/simulation/replay.rs
@@ -1,0 +1,69 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use state::{GameGrid, grid::GridDelta};
+
+/// Recorded sequence of [`GridDelta`] events.
+#[derive(Clone, Debug, Default)]
+pub struct Replay {
+    deltas: Vec<GridDelta>,
+}
+
+impl Replay {
+    /// Create a replay from raw deltas.
+    pub fn new(deltas: Vec<GridDelta>) -> Self {
+        Self { deltas }
+    }
+
+    /// Access recorded deltas.
+    pub fn deltas(&self) -> &[GridDelta] {
+        &self.deltas
+    }
+
+    /// Apply the replay to a [`GameGrid`].
+    pub fn apply(&self, grid: &mut GameGrid) {
+        for delta in &self.deltas {
+            grid.apply_delta(delta.clone());
+        }
+    }
+}
+
+/// Utility for recording grid deltas during simulation.
+#[derive(Clone, Default)]
+pub struct ReplayRecorder {
+    recording: Arc<AtomicBool>,
+    deltas: Arc<Mutex<Vec<GridDelta>>>,
+}
+
+impl ReplayRecorder {
+    /// Create a new recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start recording deltas.
+    pub fn start(&self) {
+        self.deltas.lock().expect("recorder lock poisoned").clear();
+        self.recording.store(true, Ordering::SeqCst);
+    }
+
+    /// Record a delta if recording is active.
+    pub fn record(&self, delta: GridDelta) {
+        if self.recording.load(Ordering::SeqCst) {
+            self.deltas
+                .lock()
+                .expect("recorder lock poisoned")
+                .push(delta);
+        }
+    }
+
+    /// Stop recording and return the collected replay.
+    pub fn stop(&self) -> Replay {
+        self.recording.store(false, Ordering::SeqCst);
+        Replay {
+            deltas: self.deltas.lock().expect("recorder lock poisoned").clone(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add replay and determinism modules with hash-based state checking
- integrate replay recording and loading into engine API
- document completion of backlog item 8

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688dd4217e1c832d9a65cf5590ed0541