### PR TITLE
feat(engine): add configuration and game rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,8 @@ version = "0.1.0"
 dependencies = [
  "num_cpus",
  "rand",
+ "serde",
+ "serde_json",
  "state",
  "tokio",
 ]

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -28,3 +28,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Engine scheduler supporting parallel task execution ([Backlog #6](../backlog/backlog.md#6-engine-crate-%E2%80%93-scheduler)).
 - Engine systems for movement, bombs, explosions, powerups and players ([Backlog #7](../backlog/backlog.md#7-engine-crate-%E2%80%93-system-modules)).
 - Replay recording and determinism checks ([Backlog #8](../backlog/backlog.md#8-engine-crate-%E2%80%93-replay-and-determinism)).
+- Engine configuration and game rules ([Backlog #9](../backlog/backlog.md#9-engine-crate-%E2%80%93-configuration)).

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,3 +8,5 @@ rand = "0.9.1"
 num_cpus = "1.13"
 state = { path = "../state" }
 tokio = { workspace = true, features = ["sync"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/crates/engine/src/config/engine_config.rs
+++ b/crates/engine/src/config/engine_config.rs
@@ -1,0 +1,91 @@
+use std::{error::Error, fmt, fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use super::GameRules;
+
+/// Configuration for the game engine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EngineConfig {
+    /// Width of the game grid.
+    pub width: usize,
+    /// Height of the game grid.
+    pub height: usize,
+    /// Target ticks per second.
+    pub tick_rate: u32,
+    /// Game rules applied to the simulation.
+    pub rules: GameRules,
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            width: 13,
+            height: 11,
+            tick_rate: 60,
+            rules: GameRules::default(),
+        }
+    }
+}
+
+impl EngineConfig {
+    /// Load configuration from a JSON file.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let data = fs::read_to_string(path).map_err(ConfigError::Io)?;
+        serde_json::from_str(&data).map_err(ConfigError::Parse)
+    }
+
+    /// Attempt to load configuration from a file, falling back to defaults.
+    pub fn load_or_default<P: AsRef<Path>>(path: P) -> Self {
+        Self::from_path(path).unwrap_or_default()
+    }
+}
+
+/// Errors that may occur while loading configuration.
+#[derive(Debug)]
+pub enum ConfigError {
+    Io(std::io::Error),
+    Parse(serde_json::Error),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {}", e),
+            Self::Parse(e) => write!(f, "Parse error: {}", e),
+        }
+    }
+}
+
+impl Error for ConfigError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Parse(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn load_config_from_file() {
+        let path =
+            std::env::temp_dir().join(format!("engine_config_test_{}.json", std::process::id()));
+        let json = r#"{
+            "width": 5,
+            "height": 6,
+            "tick_rate": 30,
+            "rules": {"max_players": 2, "bomb_timer": 5, "starting_lives": 1}
+        }"#;
+        fs::write(&path, json).unwrap();
+        let cfg = EngineConfig::from_path(&path).unwrap();
+        fs::remove_file(path).unwrap();
+        assert_eq!(cfg.width, 5);
+        assert_eq!(cfg.rules.bomb_timer, 5);
+        assert_eq!(cfg.tick_rate, 30);
+    }
+}

--- a/crates/engine/src/config/game_rules.rs
+++ b/crates/engine/src/config/game_rules.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+/// Rules governing gameplay.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GameRules {
+    /// Maximum number of players allowed.
+    pub max_players: u8,
+    /// Number of ticks before a bomb explodes.
+    pub bomb_timer: u32,
+    /// Starting lives for each player.
+    pub starting_lives: u8,
+}
+
+impl Default for GameRules {
+    fn default() -> Self {
+        Self {
+            max_players: 4,
+            bomb_timer: 3,
+            starting_lives: 3,
+        }
+    }
+}

--- a/crates/engine/src/config/mod.rs
+++ b/crates/engine/src/config/mod.rs
@@ -1,0 +1,5 @@
+pub mod engine_config;
+pub mod game_rules;
+
+pub use engine_config::{ConfigError, EngineConfig};
+pub use game_rules::GameRules;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::all)]
 
 pub mod bot;
+pub mod config;
 pub mod coord;
 pub mod engine;
 pub mod game;
@@ -10,6 +11,7 @@ pub mod shrink;
 pub mod simulation;
 pub mod systems;
 
+pub use config::{ConfigError, EngineConfig, GameRules};
 pub use engine::{Engine, TaskScheduler};
 pub use simulation::{DeterminismChecker, Replay, ReplayRecorder};
 pub use systems::System;

--- a/crates/engine/src/simulation/mod.rs
+++ b/crates/engine/src/simulation/mod.rs
@@ -6,11 +6,16 @@ pub use replay::{Replay, ReplayRecorder};
 
 #[cfg(test)]
 mod tests {
-    use crate::{engine::Engine, systems::MovementSystem};
+    use crate::{config::EngineConfig, engine::Engine, systems::MovementSystem};
 
     #[test]
     fn replay_reproduces_state() {
-        let (mut engine, _rx) = Engine::new(1);
+        let cfg = EngineConfig {
+            width: 1,
+            height: 1,
+            ..EngineConfig::default()
+        };
+        let (mut engine, _rx) = Engine::new(cfg.clone());
         engine.add_system(Box::new(MovementSystem::new()));
         engine.start_replay_recording();
         for _ in 0..3 {
@@ -19,7 +24,7 @@ mod tests {
         let replay = engine.stop_replay_recording();
         let recorded_hashes = engine.determinism_hashes().to_vec();
 
-        let (mut engine2, _rx2) = Engine::new(1);
+        let (mut engine2, _rx2) = Engine::new(cfg);
         engine2.load_replay(&replay);
         assert_eq!(engine2.determinism_hashes(), recorded_hashes.as_slice());
     }

--- a/crates/engine/src/systems/mod.rs
+++ b/crates/engine/src/systems/mod.rs
@@ -35,12 +35,17 @@ pub use powerup::PowerupSystem;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::Engine;
+    use crate::{config::EngineConfig, engine::Engine};
     use state::grid::Tile;
 
     #[test]
     fn systems_interact_on_grid() {
-        let (mut engine, _rx) = Engine::new(2);
+        let cfg = EngineConfig {
+            width: 2,
+            height: 2,
+            ..EngineConfig::default()
+        };
+        let (mut engine, _rx) = Engine::new(cfg);
         engine.add_system(Box::new(MovementSystem::new()));
         engine.add_system(Box::new(PlayerSystem::new()));
         engine.add_system(Box::new(BombSystem::new()));


### PR DESCRIPTION
## Summary
- add engine config and game rules modules
- construct engine from configuration and expose accessor
- document completion of backlog item 9

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688dd6ecc29c832d98808d63a9f7fcf6