### PR TITLE
Implement event bus with basic event types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,10 +74,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -103,6 +144,9 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.1.0"
+dependencies = [
+ "crossbeam",
+]
 
 [[package]]
 name = "ffi"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -29,3 +29,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Engine systems for movement, bombs, explosions, powerups and players ([Backlog #7](../backlog/backlog.md#7-engine-crate-%E2%80%93-system-modules)).
 - Replay recording and determinism checks ([Backlog #8](../backlog/backlog.md#8-engine-crate-%E2%80%93-replay-and-determinism)).
 - Engine configuration and game rules ([Backlog #9](../backlog/backlog.md#9-engine-crate-%E2%80%93-configuration)).
+- Event types and bus with subscriber registration ([Backlog #10](../backlog/backlog.md#10-events-crate-%E2%80%93-event-types-and-bus)).

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+crossbeam = { workspace = true }

--- a/crates/events/src/bus/event_bus.rs
+++ b/crates/events/src/bus/event_bus.rs
@@ -1,0 +1,75 @@
+//! Simple event bus implementation.
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicU32, Ordering},
+};
+
+use crossbeam::channel::{Receiver, Sender, unbounded};
+
+use crate::events::Event;
+
+use super::subscriber::SubscriberId;
+
+/// Event bus capable of broadcasting events to subscribers.
+pub struct EventBus {
+    subscribers: Mutex<Vec<(SubscriberId, Sender<Event>)>>,
+    next_id: AtomicU32,
+}
+
+impl EventBus {
+    /// Creates a new, empty event bus.
+    pub fn new() -> Self {
+        Self {
+            subscribers: Mutex::new(Vec::new()),
+            next_id: AtomicU32::new(1),
+        }
+    }
+
+    /// Registers a new subscriber and returns its ID and receiver.
+    pub fn subscribe(&self) -> (SubscriberId, Receiver<Event>) {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = unbounded();
+        let mut subscribers = self.subscribers.lock().expect("lock poisoned");
+        subscribers.push((id, tx));
+        (id, rx)
+    }
+
+    /// Broadcasts an event to all subscribers.
+    pub fn broadcast(&self, event: Event) {
+        let subscribers = self.subscribers.lock().expect("lock poisoned");
+        for (_, tx) in subscribers.iter() {
+            let _ = tx.send(event.clone());
+        }
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::GameEvent;
+
+    #[test]
+    fn broadcasts_events_to_all_subscribers() {
+        let bus = EventBus::new();
+        let (_id1, rx1) = bus.subscribe();
+        let (_id2, rx2) = bus.subscribe();
+
+        bus.broadcast(Event::Game(GameEvent::TickCompleted { tick: 1 }));
+
+        assert_eq!(
+            rx1.try_recv().unwrap(),
+            Event::Game(GameEvent::TickCompleted { tick: 1 })
+        );
+        assert_eq!(
+            rx2.try_recv().unwrap(),
+            Event::Game(GameEvent::TickCompleted { tick: 1 })
+        );
+    }
+}

--- a/crates/events/src/bus/mod.rs
+++ b/crates/events/src/bus/mod.rs
@@ -1,0 +1,7 @@
+//! Event bus utilities.
+
+mod event_bus;
+mod subscriber;
+
+pub use event_bus::EventBus;
+pub use subscriber::SubscriberId;

--- a/crates/events/src/bus/subscriber.rs
+++ b/crates/events/src/bus/subscriber.rs
@@ -1,0 +1,4 @@
+//! Subscriber utilities for the event bus.
+
+/// Identifier assigned to each subscriber.
+pub type SubscriberId = u32;

--- a/crates/events/src/events/bot_events.rs
+++ b/crates/events/src/events/bot_events.rs
@@ -1,0 +1,32 @@
+//! Bot-specific events.
+
+/// Identifier for a bot instance.
+pub type BotId = usize;
+
+/// Decisions that a bot might produce.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BotDecision {
+    /// Bot chose to wait.
+    Wait,
+    /// Bot decided to place a bomb.
+    PlaceBomb,
+}
+
+/// Events emitted by or for bots.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BotEvent {
+    /// A decision was made by a bot.
+    Decision {
+        /// Identifier of the bot.
+        bot_id: BotId,
+        /// Decision made.
+        decision: BotDecision,
+    },
+    /// An error occurred for a bot.
+    Error {
+        /// Identifier of the bot.
+        bot_id: BotId,
+        /// Error message.
+        message: String,
+    },
+}

--- a/crates/events/src/events/game_events.rs
+++ b/crates/events/src/events/game_events.rs
@@ -1,0 +1,38 @@
+//! Core game events.
+
+/// Identifier for entities within the game.
+pub type EntityId = usize;
+/// Grid position represented as `(x, y)` coordinates.
+pub type Position = (u16, u16);
+/// Identifier for bombs.
+pub type BombId = usize;
+
+/// Events emitted by the game engine.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GameEvent {
+    /// An entity moved to a new position.
+    EntityMoved {
+        /// Entity identifier.
+        entity_id: EntityId,
+        /// Previous grid position.
+        old_position: Position,
+        /// New grid position.
+        new_position: Position,
+    },
+    /// A bomb was placed on the grid.
+    BombPlaced {
+        /// Identifier of the bomb owner.
+        entity_id: EntityId,
+        /// Unique bomb identifier.
+        bomb_id: BombId,
+        /// Bomb location.
+        position: Position,
+        /// Bomb power.
+        power: u8,
+    },
+    /// A game tick finished executing.
+    TickCompleted {
+        /// Tick number.
+        tick: u64,
+    },
+}

--- a/crates/events/src/events/mod.rs
+++ b/crates/events/src/events/mod.rs
@@ -1,0 +1,20 @@
+//! Event type definitions.
+
+pub mod bot_events;
+pub mod game_events;
+pub mod system_events;
+
+pub use bot_events::BotEvent;
+pub use game_events::GameEvent;
+pub use system_events::SystemEvent;
+
+/// Wrapper enum combining all event categories.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    /// Game-related event.
+    Game(GameEvent),
+    /// Bot-specific event.
+    Bot(BotEvent),
+    /// Internal system event.
+    System(SystemEvent),
+}

--- a/crates/events/src/events/system_events.rs
+++ b/crates/events/src/events/system_events.rs
@@ -1,0 +1,10 @@
+//! Internal system events.
+
+/// Events emitted for internal system lifecycle changes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SystemEvent {
+    /// The engine has started.
+    EngineStarted,
+    /// The engine is shutting down.
+    EngineStopped,
+}

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,17 +1,10 @@
-//! Temporary skeleton crate
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
-/// Initializes the crate and returns a greeting.
-pub fn init() -> &'static str {
-    "initialized"
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+//! Event definitions and bus for the Bomberman project.
 
-    #[test]
-    fn init_returns_initialized() {
-        assert_eq!(init(), "initialized");
-    }
-}
+pub mod bus;
+pub mod events;
+
+pub use bus::{EventBus, SubscriberId};
+pub use events::{BotEvent, Event, GameEvent, SystemEvent};


### PR DESCRIPTION
## Summary
- define game, bot, and system event types
- implement EventBus with subscriber registration and broadcasting
- document completed backlog item #10

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688dd9f038cc832d930c6d79900bc6c4