### PR TITLE
feat(events): add priority queue and filtering

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -30,3 +30,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Replay recording and determinism checks ([Backlog #8](../backlog/backlog.md#8-engine-crate-%E2%80%93-replay-and-determinism)).
 - Engine configuration and game rules ([Backlog #9](../backlog/backlog.md#9-engine-crate-%E2%80%93-configuration)).
 - Event types and bus with subscriber registration ([Backlog #10](../backlog/backlog.md#10-events-crate-%E2%80%93-event-types-and-bus)).
+- Event queue with priority levels and subscription filters ([Backlog #11](../backlog/backlog.md#11-events-crate-%E2%80%93-queue-and-filtering)).

--- a/crates/events/src/bus/event_bus.rs
+++ b/crates/events/src/bus/event_bus.rs
@@ -1,4 +1,4 @@
-//! Simple event bus implementation.
+//! Event bus with queuing and filtering.
 
 use std::sync::{
     Mutex,
@@ -7,14 +7,25 @@ use std::sync::{
 
 use crossbeam::channel::{Receiver, Sender, unbounded};
 
-use crate::events::Event;
+use crate::{
+    events::Event,
+    queue::{EventPriority, EventQueue},
+};
 
-use super::subscriber::SubscriberId;
+use super::{EventFilter, SubscriberId};
+
+struct Subscriber {
+    #[allow(dead_code)]
+    id: SubscriberId,
+    tx: Sender<Event>,
+    filter: Option<EventFilter>,
+}
 
 /// Event bus capable of broadcasting events to subscribers.
 pub struct EventBus {
-    subscribers: Mutex<Vec<(SubscriberId, Sender<Event>)>>,
+    subscribers: Mutex<Vec<Subscriber>>,
     next_id: AtomicU32,
+    queue: EventQueue,
 }
 
 impl EventBus {
@@ -23,23 +34,49 @@ impl EventBus {
         Self {
             subscribers: Mutex::new(Vec::new()),
             next_id: AtomicU32::new(1),
+            queue: EventQueue::new(),
         }
     }
 
-    /// Registers a new subscriber and returns its ID and receiver.
+    /// Registers a new subscriber without a filter and returns its ID and receiver.
     pub fn subscribe(&self) -> (SubscriberId, Receiver<Event>) {
+        self.subscribe_with_filter(None)
+    }
+
+    /// Registers a new subscriber with an optional filter.
+    pub fn subscribe_with_filter(
+        &self,
+        filter: Option<EventFilter>,
+    ) -> (SubscriberId, Receiver<Event>) {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = unbounded();
         let mut subscribers = self.subscribers.lock().expect("lock poisoned");
-        subscribers.push((id, tx));
+        subscribers.push(Subscriber { id, tx, filter });
         (id, rx)
     }
 
-    /// Broadcasts an event to all subscribers.
+    /// Enqueues an event with a priority to be processed later.
+    pub fn emit(&self, event: Event, priority: EventPriority) {
+        self.queue.push(event, priority);
+    }
+
+    /// Processes all queued events, delivering them to subscribers.
+    pub fn process(&self) -> usize {
+        let mut count = 0;
+        while let Some(event) = self.queue.pop() {
+            self.broadcast(event);
+            count += 1;
+        }
+        count
+    }
+
+    /// Broadcasts an event immediately to all matching subscribers.
     pub fn broadcast(&self, event: Event) {
         let subscribers = self.subscribers.lock().expect("lock poisoned");
-        for (_, tx) in subscribers.iter() {
-            let _ = tx.send(event.clone());
+        for subscriber in subscribers.iter() {
+            if subscriber.filter.as_ref().is_none_or(|f| f.matches(&event)) {
+                let _ = subscriber.tx.send(event.clone());
+            }
         }
     }
 }
@@ -53,7 +90,7 @@ impl Default for EventBus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::GameEvent;
+    use crate::events::{BotDecision, BotEvent, GameEvent};
 
     #[test]
     fn broadcasts_events_to_all_subscribers() {
@@ -71,5 +108,56 @@ mod tests {
             rx2.try_recv().unwrap(),
             Event::Game(GameEvent::TickCompleted { tick: 1 })
         );
+    }
+
+    #[test]
+    fn processes_events_by_priority() {
+        let bus = EventBus::new();
+        let (_id, rx) = bus.subscribe();
+
+        bus.emit(
+            Event::Game(GameEvent::TickCompleted { tick: 1 }),
+            EventPriority::Low,
+        );
+        bus.emit(
+            Event::Game(GameEvent::TickCompleted { tick: 2 }),
+            EventPriority::High,
+        );
+        bus.process();
+
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            Event::Game(GameEvent::TickCompleted { tick: 2 })
+        );
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            Event::Game(GameEvent::TickCompleted { tick: 1 })
+        );
+    }
+
+    #[test]
+    fn filters_events_for_subscribers() {
+        let bus = EventBus::new();
+        let filter = EventFilter::new(|e| matches!(e, Event::Game(_)));
+        let (_id, rx) = bus.subscribe_with_filter(Some(filter));
+
+        bus.emit(
+            Event::Game(GameEvent::TickCompleted { tick: 3 }),
+            EventPriority::Normal,
+        );
+        bus.emit(
+            Event::Bot(BotEvent::Decision {
+                bot_id: 1,
+                decision: BotDecision::Wait,
+            }),
+            EventPriority::Normal,
+        );
+        bus.process();
+
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            Event::Game(GameEvent::TickCompleted { tick: 3 })
+        );
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/crates/events/src/bus/filter.rs
+++ b/crates/events/src/bus/filter.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use crate::events::Event;
+
+/// Filter applied to subscriber delivery.
+#[derive(Clone)]
+pub struct EventFilter {
+    predicate: Arc<dyn Fn(&Event) -> bool + Send + Sync>,
+}
+
+impl EventFilter {
+    /// Creates a new filter from the given predicate.
+    pub fn new<F>(predicate: F) -> Self
+    where
+        F: Fn(&Event) -> bool + Send + Sync + 'static,
+    {
+        Self {
+            predicate: Arc::new(predicate),
+        }
+    }
+
+    /// Returns true if the event matches the filter.
+    pub fn matches(&self, event: &Event) -> bool {
+        (self.predicate)(event)
+    }
+}

--- a/crates/events/src/bus/mod.rs
+++ b/crates/events/src/bus/mod.rs
@@ -1,7 +1,9 @@
 //! Event bus utilities.
 
 mod event_bus;
+mod filter;
 mod subscriber;
 
 pub use event_bus::EventBus;
+pub use filter::EventFilter;
 pub use subscriber::SubscriberId;

--- a/crates/events/src/events/mod.rs
+++ b/crates/events/src/events/mod.rs
@@ -4,7 +4,7 @@ pub mod bot_events;
 pub mod game_events;
 pub mod system_events;
 
-pub use bot_events::BotEvent;
+pub use bot_events::{BotDecision, BotEvent};
 pub use game_events::GameEvent;
 pub use system_events::SystemEvent;
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -5,6 +5,8 @@
 
 pub mod bus;
 pub mod events;
+pub mod queue;
 
-pub use bus::{EventBus, SubscriberId};
-pub use events::{BotEvent, Event, GameEvent, SystemEvent};
+pub use bus::{EventBus, EventFilter, SubscriberId};
+pub use events::{BotDecision, BotEvent, Event, GameEvent, SystemEvent};
+pub use queue::EventPriority;

--- a/crates/events/src/queue/mod.rs
+++ b/crates/events/src/queue/mod.rs
@@ -1,0 +1,5 @@
+//! Event queue management.
+
+mod priority_queue;
+
+pub use priority_queue::{EventPriority, EventQueue};

--- a/crates/events/src/queue/priority_queue.rs
+++ b/crates/events/src/queue/priority_queue.rs
@@ -1,0 +1,106 @@
+use crossbeam::queue::SegQueue;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::events::Event;
+
+/// Priority levels for events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventPriority {
+    /// High priority events are processed first.
+    High,
+    /// Normal priority events are processed after high priority.
+    Normal,
+    /// Low priority events are processed last.
+    Low,
+}
+
+/// Thread-safe queue holding events across three priority levels.
+pub struct EventQueue {
+    high: SegQueue<Event>,
+    normal: SegQueue<Event>,
+    low: SegQueue<Event>,
+    pending: AtomicUsize,
+}
+
+impl EventQueue {
+    /// Creates an empty event queue.
+    pub fn new() -> Self {
+        Self {
+            high: SegQueue::new(),
+            normal: SegQueue::new(),
+            low: SegQueue::new(),
+            pending: AtomicUsize::new(0),
+        }
+    }
+
+    /// Pushes an event with the specified priority.
+    pub fn push(&self, event: Event, priority: EventPriority) {
+        match priority {
+            EventPriority::High => self.high.push(event),
+            EventPriority::Normal => self.normal.push(event),
+            EventPriority::Low => self.low.push(event),
+        }
+        self.pending.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Pops the next event in priority order.
+    pub fn pop(&self) -> Option<Event> {
+        let event = self
+            .high
+            .pop()
+            .or_else(|| self.normal.pop())
+            .or_else(|| self.low.pop());
+
+        if event.is_some() {
+            self.pending.fetch_sub(1, Ordering::Relaxed);
+        }
+        event
+    }
+
+    /// Returns the number of pending events.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.pending.load(Ordering::Relaxed)
+    }
+
+    /// Returns true if the queue has no events.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.pending.load(Ordering::Relaxed) == 0
+    }
+}
+
+impl Default for EventQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::GameEvent;
+
+    #[test]
+    fn pops_high_priority_first() {
+        let queue = EventQueue::new();
+        queue.push(
+            Event::Game(GameEvent::TickCompleted { tick: 1 }),
+            EventPriority::Low,
+        );
+        queue.push(
+            Event::Game(GameEvent::TickCompleted { tick: 2 }),
+            EventPriority::High,
+        );
+
+        assert_eq!(
+            queue.pop(),
+            Some(Event::Game(GameEvent::TickCompleted { tick: 2 }))
+        );
+        assert_eq!(
+            queue.pop(),
+            Some(Event::Game(GameEvent::TickCompleted { tick: 1 }))
+        );
+        assert!(queue.pop().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- add priority-based event queue
- support subscriber filters
- document completion of backlog item 11

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688ddc470d10832da9cda25a1711e86e