### PR TITLE
Add event serialization and RL transition recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,8 @@ name = "events"
 version = "0.1.0"
 dependencies = [
  "crossbeam",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -31,3 +31,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Engine configuration and game rules ([Backlog #9](../backlog/backlog.md#9-engine-crate-%E2%80%93-configuration)).
 - Event types and bus with subscriber registration ([Backlog #10](../backlog/backlog.md#10-events-crate-%E2%80%93-event-types-and-bus)).
 - Event queue with priority levels and subscription filters ([Backlog #11](../backlog/backlog.md#11-events-crate-%E2%80%93-queue-and-filtering)).
+- Event serialization and RL transition recording ([Backlog #12](../backlog/backlog.md#12-events-crate-%E2%80%93-serialization-and-recording)).

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 crossbeam = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/events/src/events/bot_events.rs
+++ b/crates/events/src/events/bot_events.rs
@@ -3,8 +3,10 @@
 /// Identifier for a bot instance.
 pub type BotId = usize;
 
+use serde::{Deserialize, Serialize};
+
 /// Decisions that a bot might produce.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BotDecision {
     /// Bot chose to wait.
     Wait,
@@ -13,7 +15,7 @@ pub enum BotDecision {
 }
 
 /// Events emitted by or for bots.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BotEvent {
     /// A decision was made by a bot.
     Decision {

--- a/crates/events/src/events/game_events.rs
+++ b/crates/events/src/events/game_events.rs
@@ -7,8 +7,10 @@ pub type Position = (u16, u16);
 /// Identifier for bombs.
 pub type BombId = usize;
 
+use serde::{Deserialize, Serialize};
+
 /// Events emitted by the game engine.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GameEvent {
     /// An entity moved to a new position.
     EntityMoved {

--- a/crates/events/src/events/mod.rs
+++ b/crates/events/src/events/mod.rs
@@ -9,7 +9,10 @@ pub use game_events::GameEvent;
 pub use system_events::SystemEvent;
 
 /// Wrapper enum combining all event categories.
-#[derive(Debug, Clone, PartialEq)]
+use serde::{Deserialize, Serialize};
+
+/// Wrapper enum combining all event categories.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Event {
     /// Game-related event.
     Game(GameEvent),

--- a/crates/events/src/events/system_events.rs
+++ b/crates/events/src/events/system_events.rs
@@ -1,7 +1,9 @@
 //! Internal system events.
 
+use serde::{Deserialize, Serialize};
+
 /// Events emitted for internal system lifecycle changes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SystemEvent {
     /// The engine has started.
     EngineStarted,

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -6,7 +6,9 @@
 pub mod bus;
 pub mod events;
 pub mod queue;
+pub mod serialization;
 
 pub use bus::{EventBus, EventFilter, SubscriberId};
 pub use events::{BotDecision, BotEvent, Event, GameEvent, SystemEvent};
 pub use queue::EventPriority;
+pub use serialization::{Transition, TransitionRecorder, decoder, encoder};

--- a/crates/events/src/queue/priority_queue.rs
+++ b/crates/events/src/queue/priority_queue.rs
@@ -2,9 +2,10 @@ use crossbeam::queue::SegQueue;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::events::Event;
+use serde::{Deserialize, Serialize};
 
 /// Priority levels for events.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EventPriority {
     /// High priority events are processed first.
     High,

--- a/crates/events/src/serialization/decoder.rs
+++ b/crates/events/src/serialization/decoder.rs
@@ -1,0 +1,13 @@
+//! JSON decoder for events and transitions.
+
+use crate::{events::Event, serialization::Transition};
+
+/// Decodes an [`Event`] from a JSON string.
+pub fn decode_event(json: &str) -> serde_json::Result<Event> {
+    serde_json::from_str(json)
+}
+
+/// Decodes a [`Transition`] from a JSON string.
+pub fn decode_transition(json: &str) -> serde_json::Result<Transition> {
+    serde_json::from_str(json)
+}

--- a/crates/events/src/serialization/encoder.rs
+++ b/crates/events/src/serialization/encoder.rs
@@ -1,0 +1,13 @@
+//! JSON encoder for events and transitions.
+
+use crate::{events::Event, serialization::Transition};
+
+/// Encodes an [`Event`] into a JSON string.
+pub fn encode_event(event: &Event) -> serde_json::Result<String> {
+    serde_json::to_string(event)
+}
+
+/// Encodes a [`Transition`] into a JSON string.
+pub fn encode_transition(transition: &Transition) -> serde_json::Result<String> {
+    serde_json::to_string(transition)
+}

--- a/crates/events/src/serialization/mod.rs
+++ b/crates/events/src/serialization/mod.rs
@@ -1,0 +1,82 @@
+//! Serialization utilities for events and RL transitions.
+
+use serde::{Deserialize, Serialize};
+
+pub mod decoder;
+pub mod encoder;
+
+/// RL transition record used for learning.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Transition {
+    /// Observation before taking an action.
+    pub obs: Vec<f32>,
+    /// Action taken by the agent.
+    pub action: i32,
+    /// Reward obtained after the action.
+    pub reward: f32,
+    /// Observation after taking the action.
+    pub next_obs: Vec<f32>,
+    /// Whether the episode has terminated.
+    pub done: bool,
+}
+
+/// Recorder that accumulates transitions during gameplay.
+#[derive(Debug, Default)]
+pub struct TransitionRecorder {
+    transitions: Vec<Transition>,
+}
+
+impl TransitionRecorder {
+    /// Creates a new, empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a transition constructed from components.
+    pub fn record(
+        &mut self,
+        obs: Vec<f32>,
+        action: i32,
+        reward: f32,
+        next_obs: Vec<f32>,
+        done: bool,
+    ) {
+        let transition = Transition {
+            obs,
+            action,
+            reward,
+            next_obs,
+            done,
+        };
+        self.transitions.push(transition);
+    }
+
+    /// Returns all recorded transitions.
+    pub fn transitions(&self) -> &[Transition] {
+        &self.transitions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::{Event, GameEvent};
+
+    #[test]
+    fn event_serialization_round_trip() {
+        let event = Event::Game(GameEvent::TickCompleted { tick: 7 });
+        let json = encoder::encode_event(&event).unwrap();
+        let decoded = decoder::decode_event(&json).unwrap();
+        assert_eq!(event, decoded);
+    }
+
+    #[test]
+    fn transition_record_and_round_trip() {
+        let mut recorder = TransitionRecorder::new();
+        recorder.record(vec![0.1, 0.2], 1, 0.5, vec![0.3, 0.4], true);
+        let transition = &recorder.transitions()[0];
+        let json = encoder::encode_transition(transition).unwrap();
+        let decoded = decoder::decode_transition(&json).unwrap();
+        assert_eq!(*transition, decoded);
+    }
+}


### PR DESCRIPTION
## Summary
- enable JSON encode/decode of events
- record RL transitions and serialize them
- document completion of backlog item 12

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688ddec63f5c832d81f075920015d499