### PR TITLE
Implement InfluenceMap core with danger and opportunity layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,10 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "influence"
 version = "0.1.0"
+dependencies = [
+ "state",
+ "thiserror",
+]
 
 [[package]]
 name = "io-uring"
@@ -485,6 +489,26 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tch = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = "1"
+thiserror = "1"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -32,3 +32,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Event types and bus with subscriber registration ([Backlog #10](../backlog/backlog.md#10-events-crate-%E2%80%93-event-types-and-bus)).
 - Event queue with priority levels and subscription filters ([Backlog #11](../backlog/backlog.md#11-events-crate-%E2%80%93-queue-and-filtering)).
 - Event serialization and RL transition recording ([Backlog #12](../backlog/backlog.md#12-events-crate-%E2%80%93-serialization-and-recording)).
+- Influence map core with danger and opportunity layers ([Backlog #13](../backlog/backlog.md#13-influence-map-crate-%E2%80%93-core-map)).

--- a/crates/influence/Cargo.toml
+++ b/crates/influence/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+state = { path = "../state" }
+thiserror = { workspace = true }

--- a/crates/influence/src/core/danger.rs
+++ b/crates/influence/src/core/danger.rs
@@ -1,0 +1,89 @@
+//! Danger layer implementation.
+
+use std::any::Any;
+
+use state::GameState;
+
+use super::{DirtyRegion, InfluenceType, layer::InfluenceLayer};
+
+/// A danger source such as a bomb.
+#[derive(Debug, Clone, Copy)]
+pub struct DangerSource {
+    /// X coordinate.
+    pub x: u16,
+    /// Y coordinate.
+    pub y: u16,
+    /// Base strength of the influence.
+    pub strength: f32,
+    /// Maximum propagation range measured in Manhattan distance.
+    pub range: u16,
+}
+
+/// Influence layer representing dangers.
+pub struct DangerMap {
+    width: u16,
+    data: Vec<f32>,
+    sources: Vec<DangerSource>,
+}
+
+impl DangerMap {
+    /// Creates a new danger map.
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            width,
+            data: vec![0.0; width as usize * height as usize],
+            sources: Vec::new(),
+        }
+    }
+
+    fn index(&self, x: u16, y: u16) -> usize {
+        y as usize * self.width as usize + x as usize
+    }
+
+    /// Adds a source to the map.
+    pub fn add_source(&mut self, source: DangerSource) {
+        self.sources.push(source);
+    }
+}
+
+impl InfluenceLayer for DangerMap {
+    fn get_influence(&self, x: u16, y: u16) -> f32 {
+        self.data[self.index(x, y)]
+    }
+
+    fn set_influence(&mut self, x: u16, y: u16, value: f32) {
+        let idx = self.index(x, y);
+        self.data[idx] = value;
+    }
+
+    fn update(&mut self, _state: &GameState, dirty: &[DirtyRegion]) {
+        for region in dirty {
+            for y in region.y..region.y + region.height {
+                for x in region.x..region.x + region.width {
+                    let mut value = 0.0;
+                    for src in &self.sources {
+                        let dist = x.abs_diff(src.x) + y.abs_diff(src.y);
+                        if dist <= src.range {
+                            let influence = src.strength * (1.0 - dist as f32 / src.range as f32);
+                            value += influence;
+                        }
+                    }
+                    self.set_influence(x, y, value);
+                }
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.data.fill(0.0);
+        self.sources.clear();
+    }
+
+    fn get_layer_type(&self) -> InfluenceType {
+        InfluenceType::Danger
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/crates/influence/src/core/influence_map.rs
+++ b/crates/influence/src/core/influence_map.rs
@@ -1,0 +1,180 @@
+//! Influence map structure and management.
+
+use std::collections::HashMap;
+
+use state::GameState;
+
+use super::{
+    danger::{DangerMap, DangerSource},
+    layer::InfluenceLayer,
+    opportunity::{OpportunityMap, OpportunitySource},
+};
+
+/// Types of influence layers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InfluenceType {
+    /// Danger layer representing threats.
+    Danger,
+    /// Opportunity layer representing beneficial tiles.
+    Opportunity,
+}
+
+/// Region of the map marked as dirty needing recomputation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirtyRegion {
+    /// X coordinate of the region origin.
+    pub x: u16,
+    /// Y coordinate of the region origin.
+    pub y: u16,
+    /// Width of the region.
+    pub width: u16,
+    /// Height of the region.
+    pub height: u16,
+}
+
+/// Errors returned by influence map operations.
+#[derive(Debug, thiserror::Error)]
+pub enum InfluenceError {
+    /// Requested layer not found.
+    #[error("influence layer {0:?} not found")]
+    LayerNotFound(InfluenceType),
+}
+
+/// Main influence map containing multiple layers and dirty region tracking.
+pub struct InfluenceMap {
+    width: u16,
+    height: u16,
+    layers: HashMap<InfluenceType, Box<dyn InfluenceLayer>>,
+    dirty_regions: Vec<DirtyRegion>,
+}
+
+impl InfluenceMap {
+    /// Creates a new influence map with default danger and opportunity layers.
+    pub fn new(width: u16, height: u16) -> Self {
+        let mut layers: HashMap<InfluenceType, Box<dyn InfluenceLayer>> = HashMap::new();
+        layers.insert(
+            InfluenceType::Danger,
+            Box::new(DangerMap::new(width, height)) as Box<dyn InfluenceLayer>,
+        );
+        layers.insert(
+            InfluenceType::Opportunity,
+            Box::new(OpportunityMap::new(width, height)) as Box<dyn InfluenceLayer>,
+        );
+
+        Self {
+            width,
+            height,
+            layers,
+            dirty_regions: Vec::new(),
+        }
+    }
+
+    /// Marks a region of the map as dirty for the next update.
+    pub fn mark_dirty(&mut self, region: DirtyRegion) {
+        self.dirty_regions.push(region);
+    }
+
+    /// Returns the map width.
+    pub fn width(&self) -> u16 {
+        self.width
+    }
+
+    /// Returns the map height.
+    pub fn height(&self) -> u16 {
+        self.height
+    }
+
+    /// Adds a danger source to the underlying danger layer.
+    pub fn add_danger_source(&mut self, source: DangerSource) {
+        if let Some(layer) = self.layers.get_mut(&InfluenceType::Danger) {
+            if let Some(danger) = layer.as_any().downcast_mut::<DangerMap>() {
+                danger.add_source(source);
+            }
+        }
+    }
+
+    /// Adds an opportunity source to the underlying opportunity layer.
+    pub fn add_opportunity_source(&mut self, source: OpportunitySource) {
+        if let Some(layer) = self.layers.get_mut(&InfluenceType::Opportunity) {
+            if let Some(opportunity) = layer.as_any().downcast_mut::<OpportunityMap>() {
+                opportunity.add_source(source);
+            }
+        }
+    }
+
+    /// Recomputes layers using the provided state and current dirty regions.
+    pub fn update(&mut self, state: &GameState) -> Result<(), InfluenceError> {
+        for layer in self.layers.values_mut() {
+            layer.update(state, &self.dirty_regions);
+        }
+        self.dirty_regions.clear();
+        Ok(())
+    }
+
+    fn layer(&self, ty: InfluenceType) -> Result<&dyn InfluenceLayer, InfluenceError> {
+        self.layers
+            .get(&ty)
+            .map(|l| l.as_ref())
+            .ok_or(InfluenceError::LayerNotFound(ty))
+    }
+
+    /// Returns danger influence at coordinates.
+    pub fn danger_at(&self, x: u16, y: u16) -> Result<f32, InfluenceError> {
+        Ok(self.layer(InfluenceType::Danger)?.get_influence(x, y))
+    }
+
+    /// Returns opportunity influence at coordinates.
+    pub fn opportunity_at(&self, x: u16, y: u16) -> Result<f32, InfluenceError> {
+        Ok(self.layer(InfluenceType::Opportunity)?.get_influence(x, y))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use state::GameState;
+
+    #[test]
+    fn danger_source_updates_cells() {
+        let mut map = InfluenceMap::new(5, 5);
+        assert_eq!(map.width(), 5);
+        assert_eq!(map.height(), 5);
+        map.add_danger_source(DangerSource {
+            x: 2,
+            y: 2,
+            strength: 1.0,
+            range: 2,
+        });
+        map.mark_dirty(DirtyRegion {
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 5,
+        });
+        map.update(&GameState::new(5, 5)).unwrap();
+        assert!((map.danger_at(2, 2).unwrap() - 1.0).abs() < f32::EPSILON);
+        assert!((map.danger_at(3, 2).unwrap() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn opportunity_source_updates_cells() {
+        let mut map = InfluenceMap::new(5, 5);
+        assert_eq!(map.width(), 5);
+        assert_eq!(map.height(), 5);
+        map.add_opportunity_source(OpportunitySource {
+            x: 0,
+            y: 0,
+            value: 2.0,
+            range: 3,
+        });
+        map.mark_dirty(DirtyRegion {
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 5,
+        });
+        map.update(&GameState::new(5, 5)).unwrap();
+        assert!((map.opportunity_at(0, 0).unwrap() - 2.0).abs() < f32::EPSILON);
+        assert!((map.opportunity_at(1, 0).unwrap() - (2.0 * (1.0 - 1.0 / 3.0))).abs() < 1e-6);
+    }
+}

--- a/crates/influence/src/core/layer.rs
+++ b/crates/influence/src/core/layer.rs
@@ -1,0 +1,28 @@
+//! Trait definitions for influence layers.
+
+use std::any::Any;
+
+use state::GameState;
+
+use super::{DirtyRegion, InfluenceType};
+
+/// Trait implemented by influence map layers like danger or opportunity.
+pub trait InfluenceLayer: Send + Sync {
+    /// Returns influence value at given coordinates.
+    fn get_influence(&self, x: u16, y: u16) -> f32;
+
+    /// Sets influence value at given coordinates.
+    fn set_influence(&mut self, x: u16, y: u16, value: f32);
+
+    /// Updates the layer based on the current game state and dirty regions.
+    fn update(&mut self, state: &GameState, dirty: &[DirtyRegion]);
+
+    /// Clears layer state.
+    fn clear(&mut self);
+
+    /// Returns the layer type.
+    fn get_layer_type(&self) -> InfluenceType;
+
+    /// Converts to `Any` for downcasting.
+    fn as_any(&mut self) -> &mut dyn Any;
+}

--- a/crates/influence/src/core/mod.rs
+++ b/crates/influence/src/core/mod.rs
@@ -1,0 +1,14 @@
+//! Core module containing influence map structures and layers.
+
+/// Danger layer implementation.
+pub mod danger;
+/// Influence map container and related types.
+pub mod influence_map;
+/// Layer trait definition.
+pub mod layer;
+/// Opportunity layer implementation.
+pub mod opportunity;
+
+pub use danger::{DangerMap, DangerSource};
+pub use influence_map::{DirtyRegion, InfluenceError, InfluenceMap, InfluenceType};
+pub use opportunity::{OpportunityMap, OpportunitySource};

--- a/crates/influence/src/core/opportunity.rs
+++ b/crates/influence/src/core/opportunity.rs
@@ -1,0 +1,89 @@
+//! Opportunity layer implementation.
+
+use std::any::Any;
+
+use state::GameState;
+
+use super::{DirtyRegion, InfluenceType, layer::InfluenceLayer};
+
+/// A positive influence source such as a power-up.
+#[derive(Debug, Clone, Copy)]
+pub struct OpportunitySource {
+    /// X coordinate.
+    pub x: u16,
+    /// Y coordinate.
+    pub y: u16,
+    /// Base value of the influence.
+    pub value: f32,
+    /// Maximum propagation range measured in Manhattan distance.
+    pub range: u16,
+}
+
+/// Influence layer representing opportunities.
+pub struct OpportunityMap {
+    width: u16,
+    data: Vec<f32>,
+    sources: Vec<OpportunitySource>,
+}
+
+impl OpportunityMap {
+    /// Creates a new opportunity map.
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            width,
+            data: vec![0.0; width as usize * height as usize],
+            sources: Vec::new(),
+        }
+    }
+
+    fn index(&self, x: u16, y: u16) -> usize {
+        y as usize * self.width as usize + x as usize
+    }
+
+    /// Adds a source to the map.
+    pub fn add_source(&mut self, source: OpportunitySource) {
+        self.sources.push(source);
+    }
+}
+
+impl InfluenceLayer for OpportunityMap {
+    fn get_influence(&self, x: u16, y: u16) -> f32 {
+        self.data[self.index(x, y)]
+    }
+
+    fn set_influence(&mut self, x: u16, y: u16, value: f32) {
+        let idx = self.index(x, y);
+        self.data[idx] = value;
+    }
+
+    fn update(&mut self, _state: &GameState, dirty: &[DirtyRegion]) {
+        for region in dirty {
+            for y in region.y..region.y + region.height {
+                for x in region.x..region.x + region.width {
+                    let mut value = 0.0;
+                    for src in &self.sources {
+                        let dist = x.abs_diff(src.x) + y.abs_diff(src.y);
+                        if dist <= src.range {
+                            let influence = src.value * (1.0 - dist as f32 / src.range as f32);
+                            value += influence;
+                        }
+                    }
+                    self.set_influence(x, y, value);
+                }
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.data.fill(0.0);
+        self.sources.clear();
+    }
+
+    fn get_layer_type(&self) -> InfluenceType {
+        InfluenceType::Opportunity
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/crates/influence/src/lib.rs
+++ b/crates/influence/src/lib.rs
@@ -1,17 +1,10 @@
-//! Temporary skeleton crate
+//! Influence map crate providing danger and opportunity layers.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
-/// Initializes the crate and returns a greeting.
-pub fn init() -> &'static str {
-    "initialized"
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Core influence map functionality.
+pub mod core;
 
-    #[test]
-    fn init_returns_initialized() {
-        assert_eq!(init(), "initialized");
-    }
-}
+pub use core::{
+    DangerSource, DirtyRegion, InfluenceError, InfluenceMap, InfluenceType, OpportunitySource,
+};


### PR DESCRIPTION
## Summary
- add core InfluenceMap struct with danger and opportunity layers
- support dirty region tracking and querying of layer values
- document completed backlog item #13

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688de0c9c1e0832d85089be2f724785d