### PR TITLE
feat(influence): add update strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "events"
 version = "0.1.0"
 dependencies = [
@@ -151,8 +176,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ffi"
 version = "0.1.0"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -186,6 +223,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 name = "influence"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "state",
  "thiserror",
 ]
@@ -208,10 +246,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -250,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +326,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -320,6 +385,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +471,12 @@ checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rl"
@@ -381,6 +487,31 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -487,6 +618,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "test_utils"
 version = "0.1.0"
 
@@ -552,10 +696,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -33,3 +33,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Event queue with priority levels and subscription filters ([Backlog #11](../backlog/backlog.md#11-events-crate-%E2%80%93-queue-and-filtering)).
 - Event serialization and RL transition recording ([Backlog #12](../backlog/backlog.md#12-events-crate-%E2%80%93-serialization-and-recording)).
 - Influence map core with danger and opportunity layers ([Backlog #13](../backlog/backlog.md#13-influence-map-crate-%E2%80%93-core-map)).
+- Influence map update strategies with incremental and full options ([Backlog #14](../backlog/backlog.md#14-influence-map-crate-%E2%80%93-update-strategies)).

--- a/crates/influence/Cargo.toml
+++ b/crates/influence/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [dependencies]
 state = { path = "../state" }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/influence/src/core/influence_map.rs
+++ b/crates/influence/src/core/influence_map.rs
@@ -9,6 +9,7 @@ use super::{
     layer::InfluenceLayer,
     opportunity::{OpportunityMap, OpportunitySource},
 };
+use crate::update::{DirtyTracker, IncrementalUpdate, UpdateStrategy};
 
 /// Types of influence layers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -45,7 +46,8 @@ pub struct InfluenceMap {
     width: u16,
     height: u16,
     layers: HashMap<InfluenceType, Box<dyn InfluenceLayer>>,
-    dirty_regions: Vec<DirtyRegion>,
+    dirty: DirtyTracker,
+    strategy: Box<dyn UpdateStrategy>,
 }
 
 impl InfluenceMap {
@@ -65,13 +67,26 @@ impl InfluenceMap {
             width,
             height,
             layers,
-            dirty_regions: Vec::new(),
+            dirty: DirtyTracker::new(),
+            strategy: Box::new(IncrementalUpdate::new()),
         }
+    }
+
+    /// Creates a new map with a custom update strategy.
+    pub fn with_strategy(width: u16, height: u16, strategy: Box<dyn UpdateStrategy>) -> Self {
+        let mut map = Self::new(width, height);
+        map.strategy = strategy;
+        map
+    }
+
+    /// Sets the update strategy at runtime.
+    pub fn set_update_strategy(&mut self, strategy: Box<dyn UpdateStrategy>) {
+        self.strategy = strategy;
     }
 
     /// Marks a region of the map as dirty for the next update.
     pub fn mark_dirty(&mut self, region: DirtyRegion) {
-        self.dirty_regions.push(region);
+        self.dirty.mark(region);
     }
 
     /// Returns the map width.
@@ -91,6 +106,13 @@ impl InfluenceMap {
                 danger.add_source(source);
             }
         }
+        self.mark_dirty(region_from_source(
+            source.x,
+            source.y,
+            source.range,
+            self.width,
+            self.height,
+        ));
     }
 
     /// Adds an opportunity source to the underlying opportunity layer.
@@ -100,14 +122,24 @@ impl InfluenceMap {
                 opportunity.add_source(source);
             }
         }
+        self.mark_dirty(region_from_source(
+            source.x,
+            source.y,
+            source.range,
+            self.width,
+            self.height,
+        ));
     }
 
     /// Recomputes layers using the provided state and current dirty regions.
     pub fn update(&mut self, state: &GameState) -> Result<(), InfluenceError> {
+        self.strategy
+            .update(&mut self.dirty, self.width, self.height);
+        let regions: Vec<DirtyRegion> = self.dirty.regions().to_vec();
         for layer in self.layers.values_mut() {
-            layer.update(state, &self.dirty_regions);
+            layer.update(state, &regions);
         }
-        self.dirty_regions.clear();
+        self.dirty.clear();
         Ok(())
     }
 
@@ -129,6 +161,19 @@ impl InfluenceMap {
     }
 }
 
+fn region_from_source(x: u16, y: u16, range: u16, width: u16, height: u16) -> DirtyRegion {
+    let start_x = x.saturating_sub(range);
+    let start_y = y.saturating_sub(range);
+    let end_x = (u32::from(x) + u32::from(range)).min(u32::from(width - 1));
+    let end_y = (u32::from(y) + u32::from(range)).min(u32::from(height - 1));
+    DirtyRegion {
+        x: start_x,
+        y: start_y,
+        width: (end_x - u32::from(start_x) + 1) as u16,
+        height: (end_y - u32::from(start_y) + 1) as u16,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,12 +190,6 @@ mod tests {
             strength: 1.0,
             range: 2,
         });
-        map.mark_dirty(DirtyRegion {
-            x: 0,
-            y: 0,
-            width: 5,
-            height: 5,
-        });
         map.update(&GameState::new(5, 5)).unwrap();
         assert!((map.danger_at(2, 2).unwrap() - 1.0).abs() < f32::EPSILON);
         assert!((map.danger_at(3, 2).unwrap() - 0.5).abs() < f32::EPSILON);
@@ -166,12 +205,6 @@ mod tests {
             y: 0,
             value: 2.0,
             range: 3,
-        });
-        map.mark_dirty(DirtyRegion {
-            x: 0,
-            y: 0,
-            width: 5,
-            height: 5,
         });
         map.update(&GameState::new(5, 5)).unwrap();
         assert!((map.opportunity_at(0, 0).unwrap() - 2.0).abs() < f32::EPSILON);

--- a/crates/influence/src/lib.rs
+++ b/crates/influence/src/lib.rs
@@ -4,7 +4,10 @@
 
 /// Core influence map functionality.
 pub mod core;
+/// Update strategies and dirty region tracking.
+pub mod update;
 
 pub use core::{
     DangerSource, DirtyRegion, InfluenceError, InfluenceMap, InfluenceType, OpportunitySource,
 };
+pub use update::{FullUpdate, IncrementalUpdate, UpdateStrategy};

--- a/crates/influence/src/update/dirty_tracking.rs
+++ b/crates/influence/src/update/dirty_tracking.rs
@@ -1,0 +1,66 @@
+//! Utilities for tracking dirty regions of the influence map.
+
+use crate::core::DirtyRegion;
+
+/// Tracks regions that require recomputation.
+#[derive(Default)]
+pub struct DirtyTracker {
+    regions: Vec<DirtyRegion>,
+}
+
+impl DirtyTracker {
+    /// Creates a new tracker.
+    pub fn new() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+
+    /// Mark a region as dirty, merging with existing overlapping regions.
+    pub fn mark(&mut self, mut region: DirtyRegion) {
+        let mut i = 0;
+        while i < self.regions.len() {
+            if overlaps(self.regions[i], region) {
+                region = merge(self.regions[i], region);
+                self.regions.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        self.regions.push(region);
+    }
+
+    /// Returns the current list of dirty regions.
+    pub fn regions(&self) -> &[DirtyRegion] {
+        &self.regions
+    }
+
+    /// Clears all tracked regions.
+    pub fn clear(&mut self) {
+        self.regions.clear();
+    }
+}
+
+fn overlaps(a: DirtyRegion, b: DirtyRegion) -> bool {
+    let ax2 = u32::from(a.x) + u32::from(a.width);
+    let ay2 = u32::from(a.y) + u32::from(a.height);
+    let bx2 = u32::from(b.x) + u32::from(b.width);
+    let by2 = u32::from(b.y) + u32::from(b.height);
+    !(ax2 <= u32::from(b.x)
+        || bx2 <= u32::from(a.x)
+        || ay2 <= u32::from(b.y)
+        || by2 <= u32::from(a.y))
+}
+
+fn merge(a: DirtyRegion, b: DirtyRegion) -> DirtyRegion {
+    let x1 = a.x.min(b.x);
+    let y1 = a.y.min(b.y);
+    let x2 = (u32::from(a.x) + u32::from(a.width)).max(u32::from(b.x) + u32::from(b.width));
+    let y2 = (u32::from(a.y) + u32::from(a.height)).max(u32::from(b.y) + u32::from(b.height));
+    DirtyRegion {
+        x: x1,
+        y: y1,
+        width: (x2 - u32::from(x1)) as u16,
+        height: (y2 - u32::from(y1)) as u16,
+    }
+}

--- a/crates/influence/src/update/full.rs
+++ b/crates/influence/src/update/full.rs
@@ -1,0 +1,26 @@
+//! Full update strategy which marks the entire map as dirty each tick.
+
+use super::{DirtyTracker, UpdateStrategy};
+use crate::core::DirtyRegion;
+
+/// Strategy that always recomputes the full map.
+#[derive(Default)]
+pub struct FullUpdate;
+
+impl FullUpdate {
+    /// Creates a new [`FullUpdate`] instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl UpdateStrategy for FullUpdate {
+    fn update(&mut self, tracker: &mut DirtyTracker, width: u16, height: u16) {
+        tracker.mark(DirtyRegion {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        });
+    }
+}

--- a/crates/influence/src/update/incremental.rs
+++ b/crates/influence/src/update/incremental.rs
@@ -1,0 +1,20 @@
+//! Incremental update strategy which only recomputes already marked regions.
+
+use super::{DirtyTracker, UpdateStrategy};
+
+/// Strategy that performs no additional work beyond existing dirty regions.
+#[derive(Default)]
+pub struct IncrementalUpdate;
+
+impl IncrementalUpdate {
+    /// Creates a new [`IncrementalUpdate`] instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl UpdateStrategy for IncrementalUpdate {
+    fn update(&mut self, _tracker: &mut DirtyTracker, _width: u16, _height: u16) {
+        // Nothing to do; dirty regions are supplied externally.
+    }
+}

--- a/crates/influence/src/update/mod.rs
+++ b/crates/influence/src/update/mod.rs
@@ -1,0 +1,15 @@
+//! Update strategies for the influence map.
+
+mod dirty_tracking;
+mod full;
+mod incremental;
+
+pub use dirty_tracking::DirtyTracker;
+pub use full::FullUpdate;
+pub use incremental::IncrementalUpdate;
+
+/// Strategy for determining which regions require recomputation.
+pub trait UpdateStrategy: Send {
+    /// Populate the provided [`DirtyTracker`] with regions that should be recomputed.
+    fn update(&mut self, tracker: &mut DirtyTracker, width: u16, height: u16);
+}

--- a/crates/influence/tests/update_strategies.rs
+++ b/crates/influence/tests/update_strategies.rs
@@ -1,0 +1,38 @@
+use influence::{DangerSource, FullUpdate, InfluenceMap};
+use proptest::prelude::*;
+use state::GameState;
+
+proptest! {
+    #[test]
+    fn full_matches_incremental(
+        width in 1u16..8,
+        height in 1u16..8,
+        x in 0u16..8,
+        y in 0u16..8,
+        range in 1u16..4,
+        strength in 0.0f32..5.0
+    ) {
+        let width = width.max(1);
+        let height = height.max(1);
+        let x = x % width;
+        let y = y % height;
+        let range = range.min(width.max(height));
+        let source = DangerSource { x, y, strength, range };
+        let state = GameState::new(width as usize, height as usize);
+
+        let mut full = InfluenceMap::with_strategy(width, height, Box::new(FullUpdate::new()));
+        let mut inc = InfluenceMap::new(width, height);
+
+        full.add_danger_source(source);
+        inc.add_danger_source(source);
+
+        full.update(&state).unwrap();
+        inc.update(&state).unwrap();
+
+        for yy in 0..height {
+            for xx in 0..width {
+                prop_assert!((full.danger_at(xx, yy).unwrap() - inc.danger_at(xx, yy).unwrap()).abs() < 1e-6);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce incremental and full update strategies for influence maps
- track dirty regions with merge-aware `DirtyTracker`
- automatically mark regions when sources change and expose strategy APIs
- test update strategies via property-based tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688de53ba8b8832dbe91433eebef510a