### PR TITLE
Implement path grid and heuristic modules

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -36,3 +36,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Influence map update strategies with incremental and full options ([Backlog #14](../backlog/backlog.md#14-influence-map-crate-%E2%80%93-update-strategies)).
 - Influence map visualization helpers and benchmarking ([Backlog #15](../backlog/backlog.md#15-influence-map-crate-%E2%80%93-visualization-and-benchmarking)).
 - Pathfinding algorithms A*, D* Lite and Jump Point Search ([Backlog #16](../backlog/backlog.md#16-path-crate-%E2%80%93-algorithm-implementations)).
+- Path grid and heuristic modules with Manhattan and Euclidean functions ([Backlog #17](../backlog/backlog.md#17-path-crate-%E2%80%93-grid-and-heuristics)).

--- a/crates/path/src/grid/cost.rs
+++ b/crates/path/src/grid/cost.rs
@@ -1,0 +1,12 @@
+//! Movement cost calculations.
+
+use crate::Point;
+
+use super::PathGrid;
+
+/// Returns the movement cost from `from` to `to` on the given `grid`.
+///
+/// The base cost is the destination node's cost.
+pub fn movement_cost(grid: &PathGrid, _from: Point, to: Point) -> u32 {
+    grid.node_cost(to)
+}

--- a/crates/path/src/grid/mod.rs
+++ b/crates/path/src/grid/mod.rs
@@ -1,0 +1,9 @@
+//! Grid structures for pathfinding.
+
+pub mod cost;
+pub mod node;
+pub mod path_grid;
+
+pub use cost::movement_cost;
+pub use node::Node;
+pub use path_grid::PathGrid;

--- a/crates/path/src/grid/node.rs
+++ b/crates/path/src/grid/node.rs
@@ -1,0 +1,19 @@
+//! Grid node representation.
+
+/// Represents a single grid cell.
+#[derive(Clone, Copy, Debug)]
+pub struct Node {
+    /// Whether the cell can be traversed.
+    pub walkable: bool,
+    /// Base movement cost (1 = normal).
+    pub cost: u32,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            walkable: true,
+            cost: 1,
+        }
+    }
+}

--- a/crates/path/src/grid/path_grid.rs
+++ b/crates/path/src/grid/path_grid.rs
@@ -1,0 +1,65 @@
+//! Grid implementation used for pathfinding.
+
+use super::Node;
+use crate::{Grid, Point};
+
+/// Grid backing pathfinding algorithms.
+#[derive(Clone)]
+pub struct PathGrid {
+    width: i32,
+    height: i32,
+    nodes: Vec<Node>,
+}
+
+impl PathGrid {
+    /// Creates a new `PathGrid` with the given dimensions.
+    pub fn new(width: i32, height: i32) -> Self {
+        let size = (width * height) as usize;
+        Self {
+            width,
+            height,
+            nodes: vec![Node::default(); size],
+        }
+    }
+
+    fn index(&self, p: Point) -> usize {
+        (p.y * self.width + p.x) as usize
+    }
+
+    /// Marks a cell as walkable or blocked.
+    pub fn set_walkable(&mut self, p: Point, walkable: bool) {
+        let idx = self.index(p);
+        self.nodes[idx].walkable = walkable;
+    }
+
+    /// Sets the movement cost of a cell. Minimum cost is 1.
+    pub fn set_cost(&mut self, p: Point, cost: u32) {
+        let idx = self.index(p);
+        self.nodes[idx].cost = cost.max(1);
+    }
+
+    pub(crate) fn node_cost(&self, p: Point) -> u32 {
+        let idx = self.index(p);
+        self.nodes[idx].cost
+    }
+}
+
+impl Grid for PathGrid {
+    fn width(&self) -> i32 {
+        self.width
+    }
+
+    fn height(&self) -> i32 {
+        self.height
+    }
+
+    fn is_walkable(&self, p: Point) -> bool {
+        let idx = self.index(p);
+        self.nodes[idx].walkable
+    }
+
+    fn influence(&self, p: Point) -> i32 {
+        let idx = self.index(p);
+        self.nodes[idx].cost as i32 - 1
+    }
+}

--- a/crates/path/src/heuristic/euclidean.rs
+++ b/crates/path/src/heuristic/euclidean.rs
@@ -1,0 +1,17 @@
+//! Euclidean distance heuristic.
+
+use crate::Point;
+
+use super::Heuristic;
+
+/// Euclidean distance estimator.
+#[derive(Default)]
+pub struct Euclidean;
+
+impl Heuristic for Euclidean {
+    fn distance(&self, a: Point, b: Point) -> u32 {
+        let dx = (a.x - b.x) as f64;
+        let dy = (a.y - b.y) as f64;
+        ((dx * dx + dy * dy).sqrt()) as u32
+    }
+}

--- a/crates/path/src/heuristic/manhattan.rs
+++ b/crates/path/src/heuristic/manhattan.rs
@@ -1,0 +1,15 @@
+//! Manhattan distance heuristic.
+
+use crate::Point;
+
+use super::Heuristic;
+
+/// Manhattan distance estimator.
+#[derive(Default)]
+pub struct Manhattan;
+
+impl Heuristic for Manhattan {
+    fn distance(&self, a: Point, b: Point) -> u32 {
+        ((a.x - b.x).abs() + (a.y - b.y).abs()) as u32
+    }
+}

--- a/crates/path/src/heuristic/mod.rs
+++ b/crates/path/src/heuristic/mod.rs
@@ -1,0 +1,15 @@
+//! Heuristic functions for pathfinding.
+
+use crate::Point;
+
+/// Trait implemented by heuristic strategies.
+pub trait Heuristic {
+    /// Estimates the distance between two points.
+    fn distance(&self, a: Point, b: Point) -> u32;
+}
+
+pub mod euclidean;
+pub mod manhattan;
+
+pub use euclidean::Euclidean;
+pub use manhattan::Manhattan;

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -50,5 +50,9 @@ pub trait Grid {
 }
 
 pub mod algorithms;
+pub mod grid;
+pub mod heuristic;
 
 pub use algorithms::{AStar, DStarLite, JumpPointSearch, Pathfinder};
+pub use grid::PathGrid;
+pub use heuristic::{Euclidean, Heuristic, Manhattan};

--- a/crates/path/tests/grid_tests.rs
+++ b/crates/path/tests/grid_tests.rs
@@ -1,0 +1,18 @@
+use path::grid::{PathGrid, movement_cost};
+use path::{Grid, Point};
+
+#[test]
+fn grid_setup_and_costs() {
+    let mut grid = PathGrid::new(3, 3);
+    grid.set_walkable(Point::new(1, 1), false);
+    grid.set_cost(Point::new(2, 2), 5);
+
+    assert!(!grid.is_walkable(Point::new(1, 1)));
+    assert_eq!(grid.influence(Point::new(2, 2)), 4);
+
+    let neighbors = grid.neighbors(Point::new(1, 2));
+    assert!(!neighbors.contains(&Point::new(1, 1)));
+
+    let cost = movement_cost(&grid, Point::new(0, 0), Point::new(2, 2));
+    assert_eq!(cost, 5);
+}

--- a/crates/path/tests/heuristic_tests.rs
+++ b/crates/path/tests/heuristic_tests.rs
@@ -1,0 +1,18 @@
+use path::Point;
+use path::heuristic::{Euclidean, Heuristic, Manhattan};
+
+#[test]
+fn manhattan_distance_is_correct() {
+    let h = Manhattan;
+    let a = Point::new(0, 0);
+    let b = Point::new(3, 4);
+    assert_eq!(h.distance(a, b), 7);
+}
+
+#[test]
+fn euclidean_distance_is_correct() {
+    let h = Euclidean;
+    let a = Point::new(0, 0);
+    let b = Point::new(3, 4);
+    assert_eq!(h.distance(a, b), 5);
+}


### PR DESCRIPTION
## Summary
- add grid module with `PathGrid`, `Node` and movement cost
- provide Manhattan and Euclidean heuristic implementations
- test grid setup and heuristic calculations

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688deee432ac832db02366e69e59f403