### PR TITLE
feat(path): add caching and path optimization modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,9 @@ dependencies = [
 [[package]]
 name = "path"
 version = "0.1.0"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -37,3 +37,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Influence map visualization helpers and benchmarking ([Backlog #15](../backlog/backlog.md#15-influence-map-crate-%E2%80%93-visualization-and-benchmarking)).
 - Pathfinding algorithms A*, D* Lite and Jump Point Search ([Backlog #16](../backlog/backlog.md#16-path-crate-%E2%80%93-algorithm-implementations)).
 - Path grid and heuristic modules with Manhattan and Euclidean functions ([Backlog #17](../backlog/backlog.md#17-path-crate-%E2%80%93-grid-and-heuristics)).
+- Path cache with eviction policies and path optimization algorithms ([Backlog #18](../backlog/backlog.md#18-path-crate-%E2%80%93-caching-and-optimization)).

--- a/crates/path/Cargo.toml
+++ b/crates/path/Cargo.toml
@@ -4,3 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "cache_bench"
+harness = false

--- a/crates/path/benches/cache_bench.rs
+++ b/crates/path/benches/cache_bench.rs
@@ -1,0 +1,32 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use path::cache::{CacheKey, EvictionPolicy, PathCache};
+use path::{AStar, PathGrid, Pathfinder, Point};
+
+fn bench_astar_with_cache(c: &mut Criterion) {
+    let grid = PathGrid::new(10, 10);
+    let mut astar = AStar::new();
+    let start = Point::new(0, 0);
+    let goal = Point::new(9, 9);
+
+    c.bench_function("astar_no_cache", |b| {
+        b.iter(|| {
+            black_box(astar.find_path(&grid, start, goal).unwrap());
+        })
+    });
+
+    c.bench_function("astar_with_cache", |b| {
+        let mut cache = PathCache::new(16, EvictionPolicy::Lru);
+        b.iter(|| {
+            let key = CacheKey::new(start, goal);
+            if let Some(p) = cache.get(&key) {
+                black_box(p.len());
+            } else {
+                let path = astar.find_path(&grid, start, goal).unwrap();
+                cache.insert(key, path);
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_astar_with_cache);
+criterion_main!(benches);

--- a/crates/path/src/cache/cache_key.rs
+++ b/crates/path/src/cache/cache_key.rs
@@ -1,0 +1,17 @@
+use crate::Point;
+
+/// Unique key identifying a cached path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct CacheKey {
+    /// Starting point of the path.
+    pub start: Point,
+    /// Goal point of the path.
+    pub goal: Point,
+}
+
+impl CacheKey {
+    /// Creates a new `CacheKey` from `start` and `goal` positions.
+    pub fn new(start: Point, goal: Point) -> Self {
+        Self { start, goal }
+    }
+}

--- a/crates/path/src/cache/cache_policy.rs
+++ b/crates/path/src/cache/cache_policy.rs
@@ -1,0 +1,8 @@
+/// Cache eviction strategies.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EvictionPolicy {
+    /// Least recently used entry is evicted first.
+    Lru,
+    /// First in, first out eviction.
+    Fifo,
+}

--- a/crates/path/src/cache/mod.rs
+++ b/crates/path/src/cache/mod.rs
@@ -1,0 +1,9 @@
+//! Path caching utilities.
+
+mod cache_key;
+mod cache_policy;
+mod path_cache;
+
+pub use cache_key::CacheKey;
+pub use cache_policy::EvictionPolicy;
+pub use path_cache::PathCache;

--- a/crates/path/src/cache/path_cache.rs
+++ b/crates/path/src/cache/path_cache.rs
@@ -1,0 +1,71 @@
+use std::collections::{HashMap, VecDeque};
+
+use super::{CacheKey, EvictionPolicy};
+use crate::Point;
+
+/// Stores previously computed paths with an eviction policy.
+#[derive(Debug)]
+pub struct PathCache {
+    map: HashMap<CacheKey, Vec<Point>>,
+    order: VecDeque<CacheKey>,
+    max_size: usize,
+    policy: EvictionPolicy,
+    hits: u64,
+    misses: u64,
+}
+
+impl PathCache {
+    /// Creates a new cache with the given `max_size` and `policy`.
+    pub fn new(max_size: usize, policy: EvictionPolicy) -> Self {
+        Self {
+            map: HashMap::new(),
+            order: VecDeque::new(),
+            max_size,
+            policy,
+            hits: 0,
+            misses: 0,
+        }
+    }
+
+    /// Attempts to retrieve a path from the cache.
+    pub fn get(&mut self, key: &CacheKey) -> Option<&Vec<Point>> {
+        if let Some(path) = self.map.get(key) {
+            self.hits += 1;
+            if self.policy == EvictionPolicy::Lru {
+                if let Some(pos) = self.order.iter().position(|k| k == key) {
+                    self.order.remove(pos);
+                    self.order.push_front(*key);
+                }
+            }
+            Some(path)
+        } else {
+            self.misses += 1;
+            None
+        }
+    }
+
+    /// Inserts a new path into the cache.
+    pub fn insert(&mut self, key: CacheKey, path: Vec<Point>) {
+        if self.map.contains_key(&key) {
+            if let Some(pos) = self.order.iter().position(|k| k == &key) {
+                self.order.remove(pos);
+            }
+        } else if self.map.len() == self.max_size {
+            if let Some(old_key) = self.order.pop_back() {
+                self.map.remove(&old_key);
+            }
+        }
+        self.order.push_front(key);
+        self.map.insert(key, path);
+    }
+
+    /// Number of cache hits.
+    pub fn hits(&self) -> u64 {
+        self.hits
+    }
+
+    /// Number of cache misses.
+    pub fn misses(&self) -> u64 {
+        self.misses
+    }
+}

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -50,9 +50,13 @@ pub trait Grid {
 }
 
 pub mod algorithms;
+pub mod cache;
 pub mod grid;
 pub mod heuristic;
+pub mod optimization;
 
 pub use algorithms::{AStar, DStarLite, JumpPointSearch, Pathfinder};
+pub use cache::{CacheKey, EvictionPolicy, PathCache};
 pub use grid::PathGrid;
 pub use heuristic::{Euclidean, Heuristic, Manhattan};
+pub use optimization::{simplify_path, smooth_path};

--- a/crates/path/src/optimization/mod.rs
+++ b/crates/path/src/optimization/mod.rs
@@ -1,0 +1,7 @@
+//! Path optimization algorithms.
+
+mod simplification;
+mod smoothing;
+
+pub use simplification::simplify_path;
+pub use smoothing::smooth_path;

--- a/crates/path/src/optimization/simplification.rs
+++ b/crates/path/src/optimization/simplification.rs
@@ -1,0 +1,22 @@
+use crate::Point;
+
+/// Removes intermediate points that are collinear.
+pub fn simplify_path(path: &[Point]) -> Vec<Point> {
+    if path.len() <= 2 {
+        return path.to_vec();
+    }
+    let mut result = Vec::with_capacity(path.len());
+    result.push(path[0]);
+    for window in path.windows(3) {
+        let a = window[0];
+        let b = window[1];
+        let c = window[2];
+        let ab = (b.x - a.x, b.y - a.y);
+        let bc = (c.x - b.x, c.y - b.y);
+        if ab.0 * bc.1 != ab.1 * bc.0 {
+            result.push(b);
+        }
+    }
+    result.push(*path.last().unwrap());
+    result
+}

--- a/crates/path/src/optimization/smoothing.rs
+++ b/crates/path/src/optimization/smoothing.rs
@@ -1,0 +1,48 @@
+use crate::{Grid, Point};
+
+/// Removes unnecessary waypoints when a straight line is available.
+pub fn smooth_path<G: Grid>(grid: &G, path: &[Point]) -> Vec<Point> {
+    if path.len() <= 2 {
+        return path.to_vec();
+    }
+    let mut result = Vec::with_capacity(path.len());
+    let mut i = 0;
+    while i < path.len() - 1 {
+        result.push(path[i]);
+        let mut j = i + 1;
+        for k in (i + 1)..path.len() {
+            if is_clear(grid, path[i], path[k]) {
+                j = k;
+            } else {
+                break;
+            }
+        }
+        i = j;
+    }
+    if *result.last().unwrap() != *path.last().unwrap() {
+        result.push(*path.last().unwrap());
+    }
+    result
+}
+
+fn is_clear<G: Grid>(grid: &G, a: Point, b: Point) -> bool {
+    if a.x == b.x {
+        let (start, end) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
+        for y in start..=end {
+            if !grid.is_walkable(Point::new(a.x, y)) {
+                return false;
+            }
+        }
+        true
+    } else if a.y == b.y {
+        let (start, end) = if a.x <= b.x { (a.x, b.x) } else { (b.x, a.x) };
+        for x in start..=end {
+            if !grid.is_walkable(Point::new(x, a.y)) {
+                return false;
+            }
+        }
+        true
+    } else {
+        false
+    }
+}

--- a/crates/path/tests/cache_tests.rs
+++ b/crates/path/tests/cache_tests.rs
@@ -1,0 +1,38 @@
+use path::Point;
+use path::cache::{CacheKey, EvictionPolicy, PathCache};
+
+#[test]
+fn cache_records_hits_and_misses() {
+    let mut cache = PathCache::new(2, EvictionPolicy::Lru);
+    let key = CacheKey::new(Point::new(0, 0), Point::new(1, 1));
+    assert!(cache.get(&key).is_none());
+    assert_eq!(cache.misses(), 1);
+
+    cache.insert(key, vec![Point::new(0, 0), Point::new(1, 1)]);
+    assert!(cache.get(&key).is_some());
+    assert_eq!(cache.hits(), 1);
+}
+
+#[test]
+fn lru_policy_evicts_least_recently_used() {
+    let mut cache = PathCache::new(1, EvictionPolicy::Lru);
+    let k1 = CacheKey::new(Point::new(0, 0), Point::new(1, 0));
+    let k2 = CacheKey::new(Point::new(0, 1), Point::new(1, 1));
+    cache.insert(k1, vec![Point::new(0, 0)]);
+    cache.insert(k2, vec![Point::new(0, 1)]);
+    assert!(cache.get(&k1).is_none());
+    assert!(cache.get(&k2).is_some());
+}
+
+#[test]
+fn fifo_policy_evicts_in_insertion_order() {
+    let mut cache = PathCache::new(1, EvictionPolicy::Fifo);
+    let k1 = CacheKey::new(Point::new(0, 0), Point::new(1, 0));
+    let k2 = CacheKey::new(Point::new(0, 1), Point::new(1, 1));
+    cache.insert(k1, vec![Point::new(0, 0)]);
+    // Access k1 to ensure FIFO ignores usage
+    let _ = cache.get(&k1);
+    cache.insert(k2, vec![Point::new(0, 1)]);
+    assert!(cache.get(&k1).is_none());
+    assert!(cache.get(&k2).is_some());
+}

--- a/crates/path/tests/optimization_tests.rs
+++ b/crates/path/tests/optimization_tests.rs
@@ -1,0 +1,66 @@
+use path::optimization::{simplify_path, smooth_path};
+use path::{Grid, Point};
+
+struct TestGrid {
+    width: i32,
+    height: i32,
+    blocked: Vec<bool>,
+}
+
+impl TestGrid {
+    fn new(width: i32, height: i32, blocked_cells: &[(i32, i32)]) -> Self {
+        let mut blocked = vec![false; (width * height) as usize];
+        for &(x, y) in blocked_cells {
+            blocked[(y * width + x) as usize] = true;
+        }
+        Self {
+            width,
+            height,
+            blocked,
+        }
+    }
+}
+
+impl Grid for TestGrid {
+    fn width(&self) -> i32 {
+        self.width
+    }
+    fn height(&self) -> i32 {
+        self.height
+    }
+    fn is_walkable(&self, p: Point) -> bool {
+        let idx = (p.y * self.width + p.x) as usize;
+        !self.blocked[idx]
+    }
+}
+
+#[test]
+fn simplification_removes_collinear_points() {
+    let path = vec![
+        Point::new(0, 0),
+        Point::new(1, 0),
+        Point::new(2, 0),
+        Point::new(2, 1),
+    ];
+    let simplified = simplify_path(&path);
+    assert_eq!(
+        simplified,
+        vec![Point::new(0, 0), Point::new(2, 0), Point::new(2, 1)]
+    );
+}
+
+#[test]
+fn smoothing_skips_detours() {
+    let grid = TestGrid::new(3, 2, &[(1, 0)]); // block (1,0) to force detour
+    let path = vec![
+        Point::new(0, 0),
+        Point::new(0, 1),
+        Point::new(1, 1),
+        Point::new(2, 1),
+    ];
+    let smoothed = smooth_path(&grid, &path);
+    assert_eq!(
+        smoothed,
+        vec![Point::new(0, 0), Point::new(0, 1), Point::new(2, 1)]
+    );
+}


### PR DESCRIPTION
## Summary
- add `PathCache` with LRU/FIFO eviction
- introduce path smoothing and simplification helpers
- benchmark pathfinding with cache

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo bench -p path`


------
https://chatgpt.com/codex/tasks/task_e_688df0e3d9d4832d800cac1de78985bb