### PR TITLE
Implement bomb logic crate with chain reactions and blast calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,11 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 [[package]]
 name = "bombs"
 version = "0.1.0"
+dependencies = [
+ "petgraph",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "bot"
@@ -269,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +307,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ffi"
 version = "0.1.0"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -332,6 +349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +368,16 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "influence"
@@ -520,6 +553,16 @@ name = "path"
 version = "0.1.0"
 dependencies = [
  "criterion",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -38,3 +38,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Pathfinding algorithms A*, D* Lite and Jump Point Search ([Backlog #16](../backlog/backlog.md#16-path-crate-%E2%80%93-algorithm-implementations)).
 - Path grid and heuristic modules with Manhattan and Euclidean functions ([Backlog #17](../backlog/backlog.md#17-path-crate-%E2%80%93-grid-and-heuristics)).
 - Path cache with eviction policies and path optimization algorithms ([Backlog #18](../backlog/backlog.md#18-path-crate-%E2%80%93-caching-and-optimization)).
+- Bomb logic with chain reactions and explosion calculation ([Backlog #19](../backlog/backlog.md#19-bombs-crate-%E2%80%93-bomb-logic)).

--- a/crates/bombs/Cargo.toml
+++ b/crates/bombs/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+petgraph = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/bombs/src/bomb/chain.rs
+++ b/crates/bombs/src/bomb/chain.rs
@@ -1,0 +1,128 @@
+//! Chain reaction logic for bombs.
+
+use std::collections::{HashMap, HashSet};
+
+use petgraph::Undirected;
+use petgraph::graph::Graph;
+use serde::{Deserialize, Serialize};
+
+use super::entity::{Bomb, BombId};
+
+/// Identifier for a bomb chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BombChainId(pub u32);
+
+/// Group of bombs that will explode together due to chain reactions.
+#[derive(Debug, Clone)]
+pub struct BombChain {
+    /// Chain identifier.
+    pub id: BombChainId,
+    /// Bombs contained in this chain.
+    pub bombs: Vec<BombId>,
+    /// The bomb whose timer triggers the chain.
+    pub trigger_bomb: BombId,
+    /// Tick at which the chain explodes.
+    pub explosion_time: u8,
+}
+
+/// Determines if `b1`'s explosion reaches `b2` ignoring obstacles.
+fn bombs_in_range(b1: &Bomb, b2: &Bomb) -> bool {
+    if b1.position.0 == b2.position.0 {
+        let dist = b1.position.1.abs_diff(b2.position.1);
+        dist <= b1.power as u16
+    } else if b1.position.1 == b2.position.1 {
+        let dist = b1.position.0.abs_diff(b2.position.0);
+        dist <= b1.power as u16
+    } else {
+        false
+    }
+}
+
+/// Build an undirected graph linking bombs that can trigger each other.
+fn build_bomb_graph(bombs: &HashMap<BombId, Bomb>) -> Graph<BombId, (), Undirected> {
+    let mut graph = Graph::<BombId, (), Undirected>::new_undirected();
+    let mut nodes = HashMap::<BombId, petgraph::graph::NodeIndex>::new();
+    for &id in bombs.keys() {
+        let idx = graph.add_node(id);
+        nodes.insert(id, idx);
+    }
+    let ids: Vec<_> = bombs.keys().copied().collect();
+    for i in 0..ids.len() {
+        for j in (i + 1)..ids.len() {
+            let b1 = &bombs[&ids[i]];
+            let b2 = &bombs[&ids[j]];
+            if bombs_in_range(b1, b2) || bombs_in_range(b2, b1) {
+                graph.add_edge(nodes[&ids[i]], nodes[&ids[j]], ());
+            }
+        }
+    }
+    graph
+}
+
+/// Find bomb chains based on adjacency.
+pub fn find_bomb_chains(bombs: &HashMap<BombId, Bomb>) -> Vec<BombChain> {
+    let graph = build_bomb_graph(bombs);
+    let mut chains = Vec::new();
+    let mut visited = HashSet::new();
+    let mut chain_id_counter = 0u32;
+
+    for node in graph.node_indices() {
+        if visited.contains(&node) {
+            continue;
+        }
+        let mut stack = vec![node];
+        let mut component = Vec::new();
+        while let Some(n) = stack.pop() {
+            if !visited.insert(n) {
+                continue;
+            }
+            component.push(graph[n]);
+            for neigh in graph.neighbors(n) {
+                if !visited.contains(&neigh) {
+                    stack.push(neigh);
+                }
+            }
+        }
+        let trigger = component
+            .iter()
+            .copied()
+            .min_by_key(|id| bombs[id].timer)
+            .expect("component not empty");
+        let chain = BombChain {
+            id: BombChainId(chain_id_counter),
+            bombs: component,
+            trigger_bomb: trigger,
+            explosion_time: bombs[&trigger].timer,
+        };
+        chains.push(chain);
+        chain_id_counter += 1;
+    }
+
+    chains
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_chain_reactions() {
+        let mut bombs = HashMap::new();
+        let b1 = Bomb::new(BombId(1), 0, (1, 1), 1, 2);
+        let b2 = Bomb::new(BombId(2), 0, (3, 1), 5, 2);
+        let b3 = Bomb::new(BombId(3), 0, (0, 4), 3, 1);
+        bombs.insert(b1.id, b1);
+        bombs.insert(b2.id, b2);
+        bombs.insert(b3.id, b3);
+
+        let chains = find_bomb_chains(&bombs);
+        assert_eq!(chains.len(), 2);
+        let chain = chains
+            .iter()
+            .find(|c| c.bombs.contains(&BombId(1)))
+            .unwrap();
+        assert_eq!(chain.bombs.len(), 2);
+        assert_eq!(chain.trigger_bomb, BombId(1));
+        assert_eq!(chain.explosion_time, 1);
+    }
+}

--- a/crates/bombs/src/bomb/entity.rs
+++ b/crates/bombs/src/bomb/entity.rs
@@ -1,0 +1,50 @@
+//! Bomb structure and identifiers.
+
+use serde::{Deserialize, Serialize};
+
+/// Grid position represented by (x, y).
+pub type Position = (u16, u16);
+
+/// Unique identifier for a bomb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BombId(pub u32);
+
+/// Bomb instance with properties relevant for chain reactions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bomb {
+    /// Identifier for this bomb.
+    pub id: BombId,
+    /// Identifier of the owning agent.
+    pub owner: usize,
+    /// Position on the grid.
+    pub position: Position,
+    /// Ticks until this bomb explodes.
+    pub timer: u8,
+    /// Blast radius of the bomb.
+    pub power: u8,
+    /// Whether the blast pierces through obstacles.
+    pub pierce: bool,
+    /// Whether the bomb can be detonated remotely.
+    pub remote: bool,
+    /// Whether the bomb can be kicked by agents.
+    pub kickable: bool,
+    /// Optional chain identifier this bomb belongs to.
+    pub chain_id: Option<crate::bomb::chain::BombChainId>,
+}
+
+impl Bomb {
+    /// Creates a new bomb with default flags.
+    pub fn new(id: BombId, owner: usize, position: Position, timer: u8, power: u8) -> Self {
+        Self {
+            id,
+            owner,
+            position,
+            timer,
+            power,
+            pierce: false,
+            remote: false,
+            kickable: false,
+            chain_id: None,
+        }
+    }
+}

--- a/crates/bombs/src/bomb/explosion.rs
+++ b/crates/bombs/src/bomb/explosion.rs
@@ -1,0 +1,104 @@
+//! Explosion calculation and blast radius.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use petgraph::graphmap::UnGraphMap;
+
+use super::entity::{Bomb, BombId, Position};
+
+/// Result of a bomb explosion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Explosion {
+    /// Bomb responsible for the explosion.
+    pub bomb_id: BombId,
+    /// All cells affected by the blast including the bomb's own position.
+    pub affected_cells: Vec<Position>,
+}
+
+impl Explosion {
+    /// Calculate explosion for a bomb on a grid of `size` with immutable `walls`.
+    pub fn from_bomb(bomb: &Bomb, size: (u16, u16), walls: &HashSet<Position>) -> Self {
+        let affected = blast_radius(bomb, size, walls);
+        Self {
+            bomb_id: bomb.id,
+            affected_cells: affected,
+        }
+    }
+}
+
+/// Calculate positions reached by a bomb's explosion using BFS.
+fn blast_radius(bomb: &Bomb, size: (u16, u16), walls: &HashSet<Position>) -> Vec<Position> {
+    let mut graph = UnGraphMap::<Position, ()>::new();
+    let (width, height) = size;
+    for x in 0..width {
+        for y in 0..height {
+            let pos = (x, y);
+            if walls.contains(&pos) {
+                continue;
+            }
+            graph.add_node(pos);
+        }
+    }
+    for x in 0..width {
+        for y in 0..height {
+            let pos = (x, y);
+            if walls.contains(&pos) {
+                continue;
+            }
+            if x + 1 < width && !walls.contains(&(x + 1, y)) {
+                graph.add_edge(pos, (x + 1, y), ());
+            }
+            if x > 0 && !walls.contains(&(x - 1, y)) {
+                graph.add_edge(pos, (x - 1, y), ());
+            }
+            if y + 1 < height && !walls.contains(&(x, y + 1)) {
+                graph.add_edge(pos, (x, y + 1), ());
+            }
+            if y > 0 && !walls.contains(&(x, y - 1)) {
+                graph.add_edge(pos, (x, y - 1), ());
+            }
+        }
+    }
+
+    let mut dist: HashMap<Position, u8> = HashMap::new();
+    let mut q = VecDeque::new();
+    dist.insert(bomb.position, 0);
+    q.push_back(bomb.position);
+
+    while let Some(pos) = q.pop_front() {
+        let d = dist[&pos];
+        if d >= bomb.power {
+            continue;
+        }
+        for neigh in graph.neighbors(pos) {
+            if let std::collections::hash_map::Entry::Vacant(e) = dist.entry(neigh) {
+                e.insert(d + 1);
+                q.push_back(neigh);
+            }
+        }
+    }
+
+    let mut cells: Vec<_> = dist
+        .into_iter()
+        .filter(|(_, d)| *d <= bomb.power)
+        .map(|(p, _)| p)
+        .collect();
+    cells.sort();
+    cells
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blast_respects_walls() {
+        let bomb = Bomb::new(BombId(1), 0, (1, 1), 0, 3);
+        let mut walls = HashSet::new();
+        walls.insert((2, 1));
+        let explosion = Explosion::from_bomb(&bomb, (5, 5), &walls);
+        assert!(explosion.affected_cells.contains(&(0, 1))); // left
+        assert!(!explosion.affected_cells.contains(&(3, 1))); // blocked by wall
+        assert!(explosion.affected_cells.contains(&(1, 4))); // down
+    }
+}

--- a/crates/bombs/src/bomb/mod.rs
+++ b/crates/bombs/src/bomb/mod.rs
@@ -1,0 +1,79 @@
+//! Bomb management module aggregating bomb logic.
+
+use std::collections::{HashMap, HashSet};
+
+pub mod chain;
+pub mod entity;
+pub mod explosion;
+
+use chain::{BombChain, find_bomb_chains};
+use entity::{Bomb, BombId};
+use explosion::Explosion;
+
+use thiserror::Error;
+
+/// Errors that can occur in bomb management.
+#[derive(Debug, Error)]
+pub enum BombError {
+    /// Requested bomb was not found.
+    #[error("bomb {0:?} not found")]
+    MissingBomb(BombId),
+}
+
+/// Manages active bombs and their interactions.
+#[derive(Default)]
+pub struct BombManager {
+    bombs: HashMap<BombId, Bomb>,
+}
+
+impl BombManager {
+    /// Creates a new empty manager.
+    pub fn new() -> Self {
+        Self {
+            bombs: HashMap::new(),
+        }
+    }
+
+    /// Inserts a bomb into the manager.
+    pub fn add_bomb(&mut self, bomb: Bomb) {
+        self.bombs.insert(bomb.id, bomb);
+    }
+
+    /// Returns the current bomb chains based on spatial relationships.
+    pub fn calculate_chain_reactions(&self) -> Vec<BombChain> {
+        find_bomb_chains(&self.bombs)
+    }
+
+    /// Calculates the explosion for a given bomb on a grid with `walls`.
+    pub fn calculate_explosion(
+        &self,
+        id: BombId,
+        size: (u16, u16),
+        walls: &HashSet<entity::Position>,
+    ) -> Result<Explosion, BombError> {
+        let bomb = self.bombs.get(&id).ok_or(BombError::MissingBomb(id))?;
+        Ok(Explosion::from_bomb(bomb, size, walls))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manager_computes_chain_and_explosion() {
+        let mut mgr = BombManager::new();
+        let b1 = Bomb::new(BombId(1), 0, (1, 1), 1, 2);
+        let b2 = Bomb::new(BombId(2), 0, (3, 1), 5, 2);
+        mgr.add_bomb(b1.clone());
+        mgr.add_bomb(b2.clone());
+
+        let chains = mgr.calculate_chain_reactions();
+        assert_eq!(chains.len(), 1);
+
+        let explosion = mgr
+            .calculate_explosion(b1.id, (5, 5), &HashSet::new())
+            .unwrap();
+        assert!(explosion.affected_cells.contains(&b2.position));
+    }
+}

--- a/crates/bombs/src/lib.rs
+++ b/crates/bombs/src/lib.rs
@@ -1,17 +1,12 @@
-//! Temporary skeleton crate
+//! Bomb logic crate providing chain reaction and explosion calculations.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
-/// Initializes the crate and returns a greeting.
-pub fn init() -> &'static str {
-    "initialized"
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub mod bomb;
 
-    #[test]
-    fn init_returns_initialized() {
-        assert_eq!(init(), "initialized");
-    }
-}
+pub use bomb::{
+    BombError, BombManager,
+    chain::{BombChain, BombChainId},
+    entity::{Bomb, BombId, Position},
+    explosion::Explosion,
+};


### PR DESCRIPTION
## Summary
- add Bomb entity with identifiers and properties
- compute bomb chains using petgraph graphs and manage bombs via `BombManager`
- calculate blast radii through BFS over a grid and expose `Explosion`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688df38bb894832d87c0b23c6129f9fd