### PR TITLE
feat(bombs): add power analysis modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ name = "bombs"
 version = "0.1.0"
 dependencies = [
  "petgraph",
+ "proptest",
  "serde",
  "thiserror",
 ]

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -40,3 +40,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Path cache with eviction policies and path optimization algorithms ([Backlog #18](../backlog/backlog.md#18-path-crate-%E2%80%93-caching-and-optimization)).
 - Bomb logic with chain reactions and explosion calculation ([Backlog #19](../backlog/backlog.md#19-bombs-crate-%E2%80%93-bomb-logic)).
 - Bomb placement strategies with safe and strategic options plus timing and remote detonation support ([Backlog #20](../backlog/backlog.md#20-bombs-crate-%E2%80%93-placement-and-timing)).
+- Bomb power effects, kicking mechanics, and analysis utilities ([Backlog #21](../backlog/backlog.md#21-bombs-crate-%E2%80%93-power-and-analysis)).

--- a/crates/bombs/Cargo.toml
+++ b/crates/bombs/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 petgraph = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/bombs/src/analysis/danger.rs
+++ b/crates/bombs/src/analysis/danger.rs
@@ -1,0 +1,56 @@
+//! Determine dangerous tiles from active bombs.
+
+use std::collections::HashSet;
+
+use crate::{
+    bomb::entity::{Bomb, Position},
+    power::affected_tiles,
+};
+
+/// Computes all tiles affected by any of the provided `bombs`.
+pub fn danger_tiles(
+    bombs: &[Bomb],
+    size: (u16, u16),
+    walls: &HashSet<Position>,
+) -> HashSet<Position> {
+    let mut danger = HashSet::new();
+    for bomb in bombs {
+        let tiles = affected_tiles(bomb.position, bomb.power, size, walls, bomb.pierce);
+        danger.extend(tiles);
+    }
+    danger
+}
+
+/// Returns `true` if `pos` is not covered by any bomb blast.
+pub fn is_safe(pos: Position, bombs: &[Bomb], size: (u16, u16), walls: &HashSet<Position>) -> bool {
+    !danger_tiles(bombs, size, walls).contains(&pos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bomb::entity::{Bomb, BombId};
+    use proptest::prelude::*;
+
+    #[test]
+    fn empty_field_is_safe() {
+        assert!(is_safe((0, 0), &[], (5, 5), &HashSet::new()));
+    }
+
+    proptest! {
+        #[test]
+        fn danger_within_power(
+            x in 0u16..5,
+            y in 0u16..5,
+            power in 1u8..4,
+        ) {
+            let bomb = Bomb::new(BombId(1), 0, (x, y), 0, power);
+            let tiles = danger_tiles(&[bomb.clone()], (5, 5), &HashSet::new());
+            prop_assert!(tiles.contains(&bomb.position));
+            for &(tx, ty) in &tiles {
+                let dist = tx.abs_diff(x) + ty.abs_diff(y);
+                prop_assert!(dist <= power as u16);
+            }
+        }
+    }
+}

--- a/crates/bombs/src/analysis/mod.rs
+++ b/crates/bombs/src/analysis/mod.rs
@@ -1,0 +1,7 @@
+//! Utilities for analyzing bomb danger and opportunities.
+
+pub mod danger;
+pub mod opportunity;
+
+pub use danger::{danger_tiles, is_safe};
+pub use opportunity::{opportunity_tiles, safe_tiles};

--- a/crates/bombs/src/analysis/opportunity.rs
+++ b/crates/bombs/src/analysis/opportunity.rs
@@ -1,0 +1,57 @@
+//! Find safe tiles and potential opportunities from bombs.
+
+use std::collections::HashSet;
+
+use crate::bomb::entity::{Bomb, Position};
+
+/// Returns all tiles safe from any bomb.
+pub fn safe_tiles(size: (u16, u16), walls: &HashSet<Position>, bombs: &[Bomb]) -> Vec<Position> {
+    let danger = super::danger::danger_tiles(bombs, size, walls);
+    let mut tiles = Vec::new();
+    for x in 0..size.0 {
+        for y in 0..size.1 {
+            let pos = (x, y);
+            if !walls.contains(&pos) && !danger.contains(&pos) {
+                tiles.push(pos);
+            }
+        }
+    }
+    tiles
+}
+
+/// Returns target positions that are hit by any bomb.
+pub fn opportunity_tiles(
+    targets: &[Position],
+    bombs: &[Bomb],
+    size: (u16, u16),
+    walls: &HashSet<Position>,
+) -> Vec<Position> {
+    let danger = super::danger::danger_tiles(bombs, size, walls);
+    targets
+        .iter()
+        .copied()
+        .filter(|p| danger.contains(p))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bomb::entity::{Bomb, BombId};
+
+    #[test]
+    fn safe_tiles_excludes_danger() {
+        let bomb = Bomb::new(BombId(1), 0, (1, 1), 0, 1);
+        let safe = safe_tiles((3, 3), &HashSet::new(), &[bomb]);
+        assert!(!safe.contains(&(1, 1)));
+        assert!(safe.contains(&(0, 0)));
+    }
+
+    #[test]
+    fn opportunity_tiles_returns_hits() {
+        let bomb = Bomb::new(BombId(1), 0, (0, 0), 0, 2);
+        let targets = vec![(2, 0), (1, 2), (0, 2)];
+        let hits = opportunity_tiles(&targets, &[bomb], (5, 5), &HashSet::new());
+        assert_eq!(hits, vec![(2, 0), (0, 2)]);
+    }
+}

--- a/crates/bombs/src/lib.rs
+++ b/crates/bombs/src/lib.rs
@@ -2,8 +2,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
 
+pub mod analysis;
 pub mod bomb;
 pub mod placement;
+pub mod power;
 pub mod timing;
 
 pub use bomb::{
@@ -13,5 +15,7 @@ pub use bomb::{
     explosion::Explosion,
 };
 
+pub use analysis::{danger_tiles, is_safe, opportunity_tiles, safe_tiles};
 pub use placement::{PlacementStrategy, SafePlacer, StrategicPlacer};
+pub use power::{Direction, affected_tiles, kick_bomb};
 pub use timing::{BombTimer, RemoteDetonator};

--- a/crates/bombs/src/power/kick.rs
+++ b/crates/bombs/src/power/kick.rs
@@ -1,0 +1,76 @@
+//! Bomb kicking mechanics.
+
+use std::collections::HashSet;
+
+use crate::bomb::entity::{Bomb, Position};
+
+/// Directions in which a bomb can be kicked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// Move one tile up.
+    Up,
+    /// Move one tile down.
+    Down,
+    /// Move one tile left.
+    Left,
+    /// Move one tile right.
+    Right,
+}
+
+/// Attempts to kick `bomb` one tile in `dir`.
+/// Returns `true` if the bomb was moved.
+pub fn kick_bomb(
+    bomb: &mut Bomb,
+    dir: Direction,
+    size: (u16, u16),
+    walls: &HashSet<Position>,
+) -> bool {
+    if !bomb.kickable {
+        return false;
+    }
+    let (mut x, mut y) = (bomb.position.0 as i32, bomb.position.1 as i32);
+    match dir {
+        Direction::Up => y -= 1,
+        Direction::Down => y += 1,
+        Direction::Left => x -= 1,
+        Direction::Right => x += 1,
+    }
+    if x < 0 || y < 0 || x >= size.0 as i32 || y >= size.1 as i32 {
+        return false;
+    }
+    let new_pos = (x as u16, y as u16);
+    if walls.contains(&new_pos) {
+        return false;
+    }
+    bomb.position = new_pos;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bomb::entity::{Bomb, BombId};
+
+    #[test]
+    fn kick_moves_kickable_bomb() {
+        let mut bomb = Bomb::new(BombId(1), 0, (1, 1), 3, 1);
+        bomb.kickable = true;
+        assert!(kick_bomb(
+            &mut bomb,
+            Direction::Right,
+            (5, 5),
+            &HashSet::new()
+        ));
+        assert_eq!(bomb.position, (2, 1));
+    }
+
+    #[test]
+    fn kick_blocked_by_wall() {
+        let mut bomb = Bomb::new(BombId(1), 0, (1, 1), 3, 1);
+        bomb.kickable = true;
+        let mut walls = HashSet::new();
+        walls.insert((2, 1));
+        assert!(!kick_bomb(&mut bomb, Direction::Right, (5, 5), &walls));
+        assert_eq!(bomb.position, (1, 1));
+    }
+}

--- a/crates/bombs/src/power/mod.rs
+++ b/crates/bombs/src/power/mod.rs
@@ -1,0 +1,7 @@
+//! Bomb power effects and kicking mechanics.
+
+pub mod kick;
+pub mod power_calc;
+
+pub use kick::{Direction, kick_bomb};
+pub use power_calc::affected_tiles;

--- a/crates/bombs/src/power/power_calc.rs
+++ b/crates/bombs/src/power/power_calc.rs
@@ -1,0 +1,59 @@
+//! Calculation of tiles affected by bomb power.
+
+use std::collections::HashSet;
+
+use crate::bomb::entity::Position;
+
+/// Computes the set of tiles affected by a bomb at `position` with a given `power`.
+///
+/// * `size` - Grid dimensions `(width, height)`.
+/// * `walls` - Positions that block blast propagation.
+/// * `pierce` - If true, blast continues past walls.
+pub fn affected_tiles(
+    position: Position,
+    power: u8,
+    size: (u16, u16),
+    walls: &HashSet<Position>,
+    pierce: bool,
+) -> HashSet<Position> {
+    let mut tiles = HashSet::new();
+    tiles.insert(position);
+
+    let directions = [(1i32, 0i32), (-1, 0), (0, 1), (0, -1)];
+    for (dx, dy) in directions {
+        let mut x = position.0 as i32;
+        let mut y = position.1 as i32;
+        for _ in 0..power {
+            x += dx;
+            y += dy;
+            if x < 0 || y < 0 || x >= size.0 as i32 || y >= size.1 as i32 {
+                break;
+            }
+            let pos = (x as u16, y as u16);
+            if walls.contains(&pos) {
+                if pierce {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            tiles.insert(pos);
+        }
+    }
+
+    tiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn power_respects_bounds_and_walls() {
+        let mut walls = HashSet::new();
+        walls.insert((2, 1));
+        let tiles = affected_tiles((1, 1), 3, (5, 5), &walls, false);
+        assert!(tiles.contains(&(1, 4))); // down
+        assert!(!tiles.contains(&(3, 1))); // blocked by wall
+    }
+}


### PR DESCRIPTION
## Summary
- add bomb power calculations and kicking support
- provide danger and opportunity analysis utilities
- document completion of backlog item 21

## Testing
- `cargo test -p bombs`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688e00669fd4832d95a6f9629b5caa5f