### PR TITLE
feat(goals): add execution and hierarchy modules

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -42,3 +42,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Bomb placement strategies with safe and strategic options plus timing and remote detonation support ([Backlog #20](../backlog/backlog.md#20-bombs-crate-%E2%80%93-placement-and-timing)).
 - Bomb power effects, kicking mechanics, and analysis utilities ([Backlog #21](../backlog/backlog.md#21-bombs-crate-%E2%80%93-power-and-analysis)).
 - Goal definitions and planner ([Backlog #22](../backlog/backlog.md#22-goals-crate-%E2%80%93-goal-definitions-and-planner)).
+- Goal execution and hierarchy management ([Backlog #23](../backlog/backlog.md#23-goals-crate-%E2%80%93-execution-and-hierarchy)).

--- a/crates/goals/src/executor/executor.rs
+++ b/crates/goals/src/executor/executor.rs
@@ -1,0 +1,39 @@
+//! Goal execution coordinating planner output and progress monitoring.
+
+use state::GameState;
+
+use crate::goal::{Action, BotId, GoalError};
+use crate::planner::GoalPlanner;
+
+use super::monitor::ProgressMonitor;
+
+/// Executes the active goal from a planner while tracking progress.
+pub struct GoalExecutor {
+    monitor: ProgressMonitor,
+}
+
+impl GoalExecutor {
+    /// Creates a new executor with the given progress monitor.
+    pub fn new(monitor: ProgressMonitor) -> Self {
+        Self { monitor }
+    }
+
+    /// Runs one tick of the active goal, returning actions to perform.
+    pub fn execute(
+        &mut self,
+        planner: &mut GoalPlanner,
+        state: &GameState,
+        bot_id: BotId,
+    ) -> Result<Vec<Action>, GoalError> {
+        let actions = planner.execute_active_goal(state, bot_id)?;
+        if let Some(ref active) = planner.active_goal {
+            self.monitor.update(active.progress);
+        }
+        Ok(actions)
+    }
+
+    /// Whether the executor considers the active goal stalled.
+    pub fn is_stalled(&self) -> bool {
+        self.monitor.is_stalled()
+    }
+}

--- a/crates/goals/src/executor/mod.rs
+++ b/crates/goals/src/executor/mod.rs
@@ -1,0 +1,10 @@
+#![allow(clippy::module_inception)]
+//! Goal execution helpers.
+
+/// Goal execution logic.
+pub mod executor;
+/// Progress monitoring utilities.
+pub mod monitor;
+
+pub use executor::GoalExecutor;
+pub use monitor::ProgressMonitor;

--- a/crates/goals/src/executor/monitor.rs
+++ b/crates/goals/src/executor/monitor.rs
@@ -1,0 +1,35 @@
+//! Progress monitoring utilities for goal execution.
+
+/// Tracks progress over ticks and detects stalls.
+#[derive(Debug, Clone)]
+pub struct ProgressMonitor {
+    last_progress: f32,
+    stagnant_ticks: u32,
+    max_stagnant_ticks: u32,
+}
+
+impl ProgressMonitor {
+    /// Creates a new monitor that flags a stall after `max_stagnant_ticks`.
+    pub fn new(max_stagnant_ticks: u32) -> Self {
+        Self {
+            last_progress: 0.0,
+            stagnant_ticks: 0,
+            max_stagnant_ticks,
+        }
+    }
+
+    /// Updates the monitor with the latest progress measurement.
+    pub fn update(&mut self, progress: f32) {
+        if progress > self.last_progress {
+            self.last_progress = progress;
+            self.stagnant_ticks = 0;
+        } else {
+            self.stagnant_ticks += 1;
+        }
+    }
+
+    /// Returns true if the monitored goal appears stalled.
+    pub fn is_stalled(&self) -> bool {
+        self.stagnant_ticks >= self.max_stagnant_ticks
+    }
+}

--- a/crates/goals/src/hierarchy/dependency.rs
+++ b/crates/goals/src/hierarchy/dependency.rs
@@ -1,0 +1,25 @@
+//! Structures describing goal dependencies.
+
+use std::collections::HashSet;
+
+use crate::goal::GoalType;
+
+/// Describes dependencies that must be completed before a goal can run.
+#[derive(Debug, Default, Clone)]
+pub struct GoalDependency {
+    prerequisites: HashSet<GoalType>,
+}
+
+impl GoalDependency {
+    /// Creates a dependency from an iterator of goal types.
+    pub fn with<I: IntoIterator<Item = GoalType>>(deps: I) -> Self {
+        Self {
+            prerequisites: deps.into_iter().collect(),
+        }
+    }
+
+    /// Returns true if all prerequisites are satisfied.
+    pub fn is_satisfied(&self, completed: &HashSet<GoalType>) -> bool {
+        self.prerequisites.is_subset(completed)
+    }
+}

--- a/crates/goals/src/hierarchy/hierarchy.rs
+++ b/crates/goals/src/hierarchy/hierarchy.rs
@@ -1,0 +1,46 @@
+//! Goal hierarchy implementation.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::goal::{Goal, GoalType};
+
+use super::dependency::GoalDependency;
+
+/// Node in the hierarchy containing a goal and its dependencies.
+pub struct GoalNode {
+    /// Goal to execute.
+    pub goal: Box<dyn Goal>,
+    /// Dependencies required before execution.
+    pub dependency: GoalDependency,
+}
+
+/// Manages hierarchical goal dependencies.
+#[derive(Default)]
+pub struct GoalHierarchy {
+    nodes: HashMap<GoalType, GoalNode>,
+    completed: HashSet<GoalType>,
+}
+
+impl GoalHierarchy {
+    /// Adds a goal with its dependency information.
+    pub fn add_goal(&mut self, goal: Box<dyn Goal>, dependency: GoalDependency) {
+        let goal_type = goal.get_goal_type();
+        self.nodes.insert(goal_type, GoalNode { goal, dependency });
+    }
+
+    /// Marks a goal type as completed.
+    pub fn mark_completed(&mut self, goal_type: GoalType) {
+        self.completed.insert(goal_type);
+    }
+
+    /// Returns goals ready for execution (dependencies satisfied).
+    pub fn next_ready(&self) -> Vec<&GoalNode> {
+        self.nodes
+            .values()
+            .filter(|node| {
+                let gtype = node.goal.get_goal_type();
+                !self.completed.contains(&gtype) && node.dependency.is_satisfied(&self.completed)
+            })
+            .collect()
+    }
+}

--- a/crates/goals/src/hierarchy/mod.rs
+++ b/crates/goals/src/hierarchy/mod.rs
@@ -1,0 +1,10 @@
+#![allow(clippy::module_inception)]
+//! Goal hierarchy and dependency management.
+
+/// Dependency tracking structures.
+pub mod dependency;
+/// Hierarchy implementation.
+pub mod hierarchy;
+
+pub use dependency::GoalDependency;
+pub use hierarchy::{GoalHierarchy, GoalNode};

--- a/crates/goals/src/lib.rs
+++ b/crates/goals/src/lib.rs
@@ -1,11 +1,17 @@
-//! Goal management crate providing goal definitions and planning.
+//! Goal management crate providing goal definitions, planning, execution, and hierarchy.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
 
+/// Goal execution utilities.
+pub mod executor;
 /// Goal definitions and utilities.
 pub mod goal;
+/// Goal hierarchy management.
+pub mod hierarchy;
 /// Goal planning utilities.
 pub mod planner;
 
+pub use executor::{GoalExecutor, ProgressMonitor};
 pub use goal::{Action, AvoidDangerGoal, BotId, CollectPowerUpGoal, Goal, GoalError, GoalType};
+pub use hierarchy::{GoalDependency, GoalHierarchy, GoalNode};
 pub use planner::{GoalPlanner, PlanningStrategy};

--- a/crates/goals/tests/executor_hierarchy_tests.rs
+++ b/crates/goals/tests/executor_hierarchy_tests.rs
@@ -1,0 +1,105 @@
+use std::sync::{Arc, Mutex};
+
+use goals::{
+    executor::{GoalExecutor, ProgressMonitor},
+    goal::{Action, BotId, Goal, GoalError, GoalType},
+    hierarchy::{GoalDependency, GoalHierarchy},
+    planner::{GoalPlanner, PlanningStrategy},
+};
+use state::GameState;
+
+#[derive(Clone)]
+struct DummyGoal {
+    goal_type: GoalType,
+    priority: f32,
+    progress: Arc<Mutex<f32>>,
+    complete_at: f32,
+}
+
+impl Goal for DummyGoal {
+    fn get_goal_type(&self) -> GoalType {
+        self.goal_type
+    }
+
+    fn get_priority(&self, _state: &GameState, _bot_id: BotId) -> f32 {
+        self.priority
+    }
+
+    fn is_achievable(&self, _state: &GameState, _bot_id: BotId) -> bool {
+        true
+    }
+
+    fn get_progress(&self, _state: &GameState, _bot_id: BotId) -> f32 {
+        *self.progress.lock().unwrap()
+    }
+
+    fn is_completed(&self, _state: &GameState, _bot_id: BotId) -> bool {
+        *self.progress.lock().unwrap() >= self.complete_at
+    }
+
+    fn plan(&self, _state: &GameState, _bot_id: BotId) -> Result<Vec<Action>, GoalError> {
+        Ok(vec![Action::Wait])
+    }
+}
+
+#[test]
+fn progress_monitor_detects_stall() {
+    let mut monitor = ProgressMonitor::new(1);
+    monitor.update(0.0);
+    monitor.update(0.0);
+    assert!(monitor.is_stalled());
+}
+
+#[test]
+fn hierarchy_executes_in_dependency_order() {
+    let state = GameState::new(1, 1);
+    let bot_id: BotId = 0;
+    let child_progress = Arc::new(Mutex::new(0.0));
+    let parent_progress = Arc::new(Mutex::new(0.0));
+
+    let child_goal = DummyGoal {
+        goal_type: GoalType::AvoidDanger,
+        priority: 1.0,
+        progress: child_progress.clone(),
+        complete_at: 1.0,
+    };
+    let parent_goal = DummyGoal {
+        goal_type: GoalType::CollectPowerUp,
+        priority: 2.0,
+        progress: parent_progress.clone(),
+        complete_at: 1.0,
+    };
+
+    let mut hierarchy = GoalHierarchy::default();
+    hierarchy.add_goal(Box::new(child_goal.clone()), GoalDependency::default());
+    hierarchy.add_goal(
+        Box::new(parent_goal.clone()),
+        GoalDependency::with([GoalType::AvoidDanger]),
+    );
+
+    let mut planner = GoalPlanner::new(PlanningStrategy::HighestScore);
+    for node in hierarchy.next_ready() {
+        planner.add_goal(node.goal.clone());
+    }
+
+    let goal = planner.select_goal(&state, bot_id).unwrap().unwrap();
+    planner.activate_goal(goal, &state, bot_id, 0).unwrap();
+    let mut executor = GoalExecutor::new(ProgressMonitor::new(2));
+    let actions = executor.execute(&mut planner, &state, bot_id).unwrap();
+    assert_eq!(actions, vec![Action::Wait]);
+    *child_progress.lock().unwrap() = 1.0;
+    let actions = executor.execute(&mut planner, &state, bot_id).unwrap();
+    assert!(actions.is_empty());
+    hierarchy.mark_completed(GoalType::AvoidDanger);
+
+    for node in hierarchy.next_ready() {
+        planner.add_goal(node.goal.clone());
+    }
+    let goal = planner.select_goal(&state, bot_id).unwrap().unwrap();
+    planner.activate_goal(goal, &state, bot_id, 1).unwrap();
+    let actions = executor.execute(&mut planner, &state, bot_id).unwrap();
+    assert_eq!(actions, vec![Action::Wait]);
+    *parent_progress.lock().unwrap() = 1.0;
+    let actions = executor.execute(&mut planner, &state, bot_id).unwrap();
+    assert!(actions.is_empty());
+}


### PR DESCRIPTION
## Summary
- add goal executor with progress monitoring
- introduce goal hierarchy with dependency tracking
- test execution flow and stalled-progress detection

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688e14f05514832db52e81e188004ea5