### PR TITLE
feat(bot): add bot kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,9 @@ dependencies = [
 [[package]]
 name = "bot"
 version = "0.1.0"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "bumpalo"

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -43,3 +43,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Bomb power effects, kicking mechanics, and analysis utilities ([Backlog #21](../backlog/backlog.md#21-bombs-crate-%E2%80%93-power-and-analysis)).
 - Goal definitions and planner ([Backlog #22](../backlog/backlog.md#22-goals-crate-%E2%80%93-goal-definitions-and-planner)).
 - Goal execution and hierarchy management ([Backlog #23](../backlog/backlog.md#23-goals-crate-%E2%80%93-execution-and-hierarchy)).
+- Bot kernel coordinating decision loop via channels ([Backlog #24](../backlog/backlog.md#24-bot-crate-%E2%80%93-core-kernel)).

--- a/crates/bot/Cargo.toml
+++ b/crates/bot/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tokio = { workspace = true }

--- a/crates/bot/src/bot/config.rs
+++ b/crates/bot/src/bot/config.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+
+/// Configuration options for a [`Bot`].
+#[derive(Debug, Clone)]
+pub struct BotConfig {
+    /// Unique identifier for the bot.
+    pub id: u32,
+    /// Maximum allowed time for making a single decision.
+    pub decision_timeout: Duration,
+}
+
+impl Default for BotConfig {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            decision_timeout: Duration::from_millis(2),
+        }
+    }
+}

--- a/crates/bot/src/bot/decision.rs
+++ b/crates/bot/src/bot/decision.rs
@@ -1,0 +1,5 @@
+/// Trait converting snapshots into commands for a [`Bot`].
+pub trait DecisionMaker<Snap, Command>: Send + 'static {
+    /// Produce a command for the provided snapshot.
+    fn decide(&mut self, snapshot: Snap) -> Command;
+}

--- a/crates/bot/src/bot/kernel.rs
+++ b/crates/bot/src/bot/kernel.rs
@@ -1,0 +1,61 @@
+use std::time::Instant;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use super::{BotConfig, BotState, DecisionMaker};
+
+/// Core bot structure coordinating decision making.
+pub struct Bot<Snap, Command>
+where
+    Snap: Send + 'static,
+    Command: Send + 'static,
+{
+    config: BotConfig,
+    snapshot_rx: UnboundedReceiver<Snap>,
+    command_tx: UnboundedSender<Command>,
+    ai: Box<dyn DecisionMaker<Snap, Command>>,
+    state: BotState,
+}
+
+impl<Snap, Command> Bot<Snap, Command>
+where
+    Snap: Send + 'static,
+    Command: Send + 'static,
+{
+    /// Create a new [`Bot`].
+    pub fn new(
+        config: BotConfig,
+        snapshot_rx: UnboundedReceiver<Snap>,
+        command_tx: UnboundedSender<Command>,
+        ai: Box<dyn DecisionMaker<Snap, Command>>,
+    ) -> Self {
+        Self {
+            config,
+            snapshot_rx,
+            command_tx,
+            ai,
+            state: BotState::default(),
+        }
+    }
+
+    /// Run the bot loop processing snapshots and emitting commands.
+    ///
+    /// The loop terminates when the snapshot channel closes or when sending
+    /// commands fails. The final [`BotState`] is returned for inspection.
+    pub async fn run(mut self) -> BotState {
+        while let Some(snapshot) = self.snapshot_rx.recv().await {
+            let start = Instant::now();
+            let command = self.ai.decide(snapshot);
+            let duration = start.elapsed();
+            self.state.record_decision(duration);
+
+            if duration > self.config.decision_timeout {
+                // In future, log or handle long decision times.
+            }
+
+            if self.command_tx.send(command).is_err() {
+                break;
+            }
+        }
+        self.state
+    }
+}

--- a/crates/bot/src/bot/mod.rs
+++ b/crates/bot/src/bot/mod.rs
@@ -1,0 +1,15 @@
+//! Core bot functionality.
+
+/// Configuration options for bots.
+pub mod config;
+/// Decision-making trait used by the kernel.
+pub mod decision;
+/// Bot kernel and run loop.
+pub mod kernel;
+/// Runtime statistics tracked for each bot.
+pub mod state;
+
+pub use config::BotConfig;
+pub use decision::DecisionMaker;
+pub use kernel::Bot;
+pub use state::BotState;

--- a/crates/bot/src/bot/state.rs
+++ b/crates/bot/src/bot/state.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+/// Runtime state tracked by a [`Bot`].
+#[derive(Default, Debug)]
+pub struct BotState {
+    decisions: usize,
+    last_duration: Option<Duration>,
+}
+
+impl BotState {
+    /// Record that a decision was made taking `duration`.
+    pub fn record_decision(&mut self, duration: Duration) {
+        self.decisions += 1;
+        self.last_duration = Some(duration);
+    }
+
+    /// Number of decisions made.
+    pub fn decisions(&self) -> usize {
+        self.decisions
+    }
+
+    /// Duration of the last decision, if any.
+    pub fn last_duration(&self) -> Option<Duration> {
+        self.last_duration
+    }
+}

--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -1,6 +1,12 @@
-//! Temporary skeleton crate
+//! Core bot crate coordinating decision making.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
+
+/// Bot kernel and related types.
+pub mod bot;
+
+pub use bot::{Bot, BotConfig, BotState, DecisionMaker};
+
 /// Initializes the crate and returns a greeting.
 pub fn init() -> &'static str {
     "initialized"

--- a/crates/bot/tests/decision_loop.rs
+++ b/crates/bot/tests/decision_loop.rs
@@ -1,0 +1,33 @@
+use bot::{Bot, BotConfig, DecisionMaker};
+use tokio::sync::mpsc;
+
+struct DummyAI;
+
+impl DecisionMaker<i32, i32> for DummyAI {
+    fn decide(&mut self, snapshot: i32) -> i32 {
+        snapshot + 1
+    }
+}
+
+#[tokio::test]
+async fn bot_processes_snapshots_and_sends_commands() {
+    let (snap_tx, snap_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+
+    let bot = Bot::new(BotConfig::default(), snap_rx, cmd_tx, Box::new(DummyAI));
+
+    let handle = tokio::spawn(bot.run());
+
+    snap_tx.send(1).unwrap();
+    snap_tx.send(41).unwrap();
+    drop(snap_tx);
+
+    let first = cmd_rx.recv().await.unwrap();
+    let second = cmd_rx.recv().await.unwrap();
+
+    assert_eq!(first, 2);
+    assert_eq!(second, 42);
+
+    let state = handle.await.unwrap();
+    assert_eq!(state.decisions(), 2);
+}


### PR DESCRIPTION
## Summary
- add `Bot` kernel that receives snapshots and sends commands via channels
- expose `BotConfig`, `BotState`, and `DecisionMaker` trait
- test the decision loop with mock snapshots

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688e1750b218832da186b78fe65f5939