### PR TITLE
feat(bot): add AI modules with dynamic switching

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -44,3 +44,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Goal definitions and planner ([Backlog #22](../backlog/backlog.md#22-goals-crate-%E2%80%93-goal-definitions-and-planner)).
 - Goal execution and hierarchy management ([Backlog #23](../backlog/backlog.md#23-goals-crate-%E2%80%93-execution-and-hierarchy)).
 - Bot kernel coordinating decision loop via channels ([Backlog #24](../backlog/backlog.md#24-bot-crate-%E2%80%93-core-kernel)).
+- AI modules with heuristic, reactive and planning strategies plus runtime switching ([Backlog #25](../backlog/backlog.md#25-bot-crate-%E2%80%93-ai-modules)).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It serves as a playground to explore the language while incrementally adopting t
 
 The project is organized as a Cargo workspace. The main engine crate lives in `crates/engine`.
 That crate exposes an `Engine` struct managing the shared `GameGrid` and broadcasting `GridDelta` events each tick.
+Baseline AI implementations reside in `crates/bot` and include heuristic,
+reactive and planning strategies that can be switched at runtime.
 
 Build and launch a tournament with the default settings:
 

--- a/crates/bot/src/ai/heuristic_ai.rs
+++ b/crates/bot/src/ai/heuristic_ai.rs
@@ -1,0 +1,22 @@
+use crate::bot::decision::DecisionMaker;
+
+/// Simple heuristic AI that increments the snapshot.
+pub struct HeuristicAI;
+
+impl DecisionMaker<i32, i32> for HeuristicAI {
+    fn decide(&mut self, snapshot: i32) -> i32 {
+        snapshot + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bot::decision::DecisionMaker;
+
+    #[test]
+    fn heuristic_ai_increments_snapshot() {
+        let mut ai = HeuristicAI;
+        assert_eq!(ai.decide(1), 2);
+    }
+}

--- a/crates/bot/src/ai/mod.rs
+++ b/crates/bot/src/ai/mod.rs
@@ -1,0 +1,75 @@
+//! AI strategy implementations.
+
+mod heuristic_ai;
+mod planning_ai;
+mod reactive_ai;
+
+pub use heuristic_ai::HeuristicAI;
+pub use planning_ai::PlanningAI;
+pub use reactive_ai::ReactiveAI;
+
+/// Available AI strategy types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AiType {
+    /// Basic heuristic-based decision making.
+    Heuristic,
+    /// Reactive AI responding directly to snapshots.
+    Reactive,
+    /// Planning AI evaluating future states.
+    Planning,
+}
+
+/// AI that can switch between different strategies at runtime.
+pub struct SwitchingAI {
+    current: AiType,
+    heuristic: HeuristicAI,
+    reactive: ReactiveAI,
+    planning: PlanningAI,
+}
+
+impl SwitchingAI {
+    /// Create a new [`SwitchingAI`] with the initial strategy [`AiType`].
+    pub fn new(initial: AiType) -> Self {
+        Self {
+            current: initial,
+            heuristic: HeuristicAI,
+            reactive: ReactiveAI,
+            planning: PlanningAI,
+        }
+    }
+
+    /// Switch to a different AI strategy.
+    pub fn switch(&mut self, new: AiType) {
+        self.current = new;
+    }
+}
+
+use crate::bot::decision::DecisionMaker;
+
+impl DecisionMaker<i32, i32> for SwitchingAI {
+    fn decide(&mut self, snapshot: i32) -> i32 {
+        match self.current {
+            AiType::Heuristic => self.heuristic.decide(snapshot),
+            AiType::Reactive => self.reactive.decide(snapshot),
+            AiType::Planning => self.planning.decide(snapshot),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bot::decision::DecisionMaker;
+
+    #[test]
+    fn switching_between_strategies_changes_behavior() {
+        let mut ai = SwitchingAI::new(AiType::Heuristic);
+        assert_eq!(ai.decide(1), 2);
+
+        ai.switch(AiType::Reactive);
+        assert_eq!(ai.decide(1), 1);
+
+        ai.switch(AiType::Planning);
+        assert_eq!(ai.decide(1), 0);
+    }
+}

--- a/crates/bot/src/ai/planning_ai.rs
+++ b/crates/bot/src/ai/planning_ai.rs
@@ -1,0 +1,22 @@
+use crate::bot::decision::DecisionMaker;
+
+/// Planning AI that decrements the snapshot to simulate forward planning.
+pub struct PlanningAI;
+
+impl DecisionMaker<i32, i32> for PlanningAI {
+    fn decide(&mut self, snapshot: i32) -> i32 {
+        snapshot - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bot::decision::DecisionMaker;
+
+    #[test]
+    fn planning_ai_decrements_snapshot() {
+        let mut ai = PlanningAI;
+        assert_eq!(ai.decide(3), 2);
+    }
+}

--- a/crates/bot/src/ai/reactive_ai.rs
+++ b/crates/bot/src/ai/reactive_ai.rs
@@ -1,0 +1,22 @@
+use crate::bot::decision::DecisionMaker;
+
+/// Reactive AI that echoes the snapshot as the command.
+pub struct ReactiveAI;
+
+impl DecisionMaker<i32, i32> for ReactiveAI {
+    fn decide(&mut self, snapshot: i32) -> i32 {
+        snapshot
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bot::decision::DecisionMaker;
+
+    #[test]
+    fn reactive_ai_echoes_snapshot() {
+        let mut ai = ReactiveAI;
+        assert_eq!(ai.decide(5), 5);
+    }
+}

--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -2,9 +2,12 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
 
+/// Built-in AI implementations.
+pub mod ai;
 /// Bot kernel and related types.
 pub mod bot;
 
+pub use ai::{AiType, HeuristicAI, PlanningAI, ReactiveAI, SwitchingAI};
 pub use bot::{Bot, BotConfig, BotState, DecisionMaker};
 
 /// Initializes the crate and returns a greeting.

--- a/crates/bot/tests/ai_modules.rs
+++ b/crates/bot/tests/ai_modules.rs
@@ -1,0 +1,40 @@
+use bot::{
+    Bot, BotConfig, DecisionMaker,
+    ai::{HeuristicAI, PlanningAI, ReactiveAI},
+};
+use tokio::sync::mpsc;
+
+async fn run_bot_with_ai<A: DecisionMaker<i32, i32> + 'static>(ai: A, snapshot: i32) -> i32 {
+    let (snap_tx, snap_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+
+    let bot = Bot::new(BotConfig::default(), snap_rx, cmd_tx, Box::new(ai));
+    let handle = tokio::spawn(bot.run());
+
+    snap_tx.send(snapshot).unwrap();
+    drop(snap_tx);
+
+    let cmd = cmd_rx.recv().await.unwrap();
+    drop(cmd_rx);
+
+    handle.await.unwrap();
+    cmd
+}
+
+#[tokio::test]
+async fn heuristic_ai_produces_incremented_command() {
+    let command = run_bot_with_ai(HeuristicAI, 1).await;
+    assert_eq!(command, 2);
+}
+
+#[tokio::test]
+async fn reactive_ai_produces_same_command() {
+    let command = run_bot_with_ai(ReactiveAI, 7).await;
+    assert_eq!(command, 7);
+}
+
+#[tokio::test]
+async fn planning_ai_produces_decremented_command() {
+    let command = run_bot_with_ai(PlanningAI, 3).await;
+    assert_eq!(command, 2);
+}


### PR DESCRIPTION
## Summary
- add heuristic, reactive, and planning AI implementations
- support runtime AI strategy switching
- document bot AI modules in README and completed features

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688e1b2ac16c832d9abb905fbf15107c