### PR TITLE
feat(bot): add perception and action modules

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -45,3 +45,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Goal execution and hierarchy management ([Backlog #23](../backlog/backlog.md#23-goals-crate-%E2%80%93-execution-and-hierarchy)).
 - Bot kernel coordinating decision loop via channels ([Backlog #24](../backlog/backlog.md#24-bot-crate-%E2%80%93-core-kernel)).
 - AI modules with heuristic, reactive and planning strategies plus runtime switching ([Backlog #25](../backlog/backlog.md#25-bot-crate-%E2%80%93-ai-modules)).
+- Perception and action modules with memory and executor ([Backlog #26](../backlog/backlog.md#26-bot-crate-%E2%80%93-perception-and-action)).

--- a/crates/bot/src/action/commands.rs
+++ b/crates/bot/src/action/commands.rs
@@ -1,0 +1,10 @@
+//! Definitions of possible bot actions.
+
+/// Minimal action set used by tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Move by the provided delta.
+    Move(i32),
+    /// Do nothing this tick.
+    Idle,
+}

--- a/crates/bot/src/action/executor.rs
+++ b/crates/bot/src/action/executor.rs
@@ -1,0 +1,49 @@
+//! Executes actions against a mutable game state.
+
+use super::{Action, ActionResult};
+
+/// Applies [`Action`]s to a mutable integer state for testing.
+#[derive(Debug, Default)]
+pub struct ActionExecutor;
+
+impl ActionExecutor {
+    /// Create a new [`ActionExecutor`].
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Execute the given action, mutating `state` when successful.
+    pub fn execute(&self, state: &mut i32, action: Action) -> ActionResult {
+        match action {
+            Action::Move(delta) if delta >= 0 => {
+                *state += delta;
+                ActionResult::Success
+            }
+            Action::Move(_) => ActionResult::Failure("negative move"),
+            Action::Idle => ActionResult::Success,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn move_action_increments_state() {
+        let exec = ActionExecutor::new();
+        let mut state = 0;
+        let result = exec.execute(&mut state, Action::Move(2));
+        assert_eq!(state, 2);
+        assert_eq!(result, ActionResult::Success);
+    }
+
+    #[test]
+    fn negative_move_fails() {
+        let exec = ActionExecutor::new();
+        let mut state = 0;
+        let result = exec.execute(&mut state, Action::Move(-1));
+        assert_eq!(state, 0);
+        assert_eq!(result, ActionResult::Failure("negative move"));
+    }
+}

--- a/crates/bot/src/action/feedback.rs
+++ b/crates/bot/src/action/feedback.rs
@@ -1,0 +1,10 @@
+//! Result of executing an [`Action`].
+
+/// Outcome of attempting to apply an action to the game state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionResult {
+    /// The action succeeded.
+    Success,
+    /// The action failed with a reason.
+    Failure(&'static str),
+}

--- a/crates/bot/src/action/mod.rs
+++ b/crates/bot/src/action/mod.rs
@@ -1,0 +1,9 @@
+//! Action handling for executing decisions in the game state.
+
+mod commands;
+mod executor;
+mod feedback;
+
+pub use commands::Action;
+pub use executor::ActionExecutor;
+pub use feedback::ActionResult;

--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -2,13 +2,19 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
 
+/// Action handling for executing decisions.
+pub mod action;
 /// Built-in AI implementations.
 pub mod ai;
 /// Bot kernel and related types.
 pub mod bot;
+/// Perception system converting snapshots into observations.
+pub mod perception;
 
+pub use action::{Action, ActionExecutor, ActionResult};
 pub use ai::{AiType, HeuristicAI, PlanningAI, ReactiveAI, SwitchingAI};
 pub use bot::{Bot, BotConfig, BotState, DecisionMaker};
+pub use perception::{BotMemory, Observation, PerceptionSystem};
 
 /// Initializes the crate and returns a greeting.
 pub fn init() -> &'static str {

--- a/crates/bot/src/perception/memory.rs
+++ b/crates/bot/src/perception/memory.rs
@@ -1,0 +1,50 @@
+//! Simple memory keeping track of recent observations.
+
+use super::Observation;
+
+/// Stores a history of observations for a bot.
+#[derive(Debug, Default)]
+pub struct BotMemory {
+    observations: Vec<Observation>,
+}
+
+impl BotMemory {
+    /// Create a new, empty [`BotMemory`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Remember a new [`Observation`].
+    pub fn remember(&mut self, obs: Observation) {
+        self.observations.push(obs);
+    }
+
+    /// Retrieve the most recent observation, if any.
+    pub fn last(&self) -> Option<Observation> {
+        self.observations.last().copied()
+    }
+
+    /// Number of stored observations.
+    pub fn len(&self) -> usize {
+        self.observations.len()
+    }
+
+    /// Returns true if no observations have been recorded.
+    pub fn is_empty(&self) -> bool {
+        self.observations.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remembering_observations_updates_memory() {
+        let mut mem = BotMemory::new();
+        assert_eq!(mem.len(), 0);
+        mem.remember(Observation::from_snapshot(1));
+        assert_eq!(mem.len(), 1);
+        assert_eq!(mem.last().unwrap().value, 1);
+    }
+}

--- a/crates/bot/src/perception/mod.rs
+++ b/crates/bot/src/perception/mod.rs
@@ -1,0 +1,9 @@
+//! Perception components converting snapshots into observations.
+
+mod memory;
+mod observation;
+mod system;
+
+pub use memory::BotMemory;
+pub use observation::Observation;
+pub use system::PerceptionSystem;

--- a/crates/bot/src/perception/observation.rs
+++ b/crates/bot/src/perception/observation.rs
@@ -1,0 +1,26 @@
+//! Processed view of a snapshot used by the AI.
+
+/// Minimal observation derived from a raw snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Observation {
+    /// Value extracted from the snapshot.
+    pub value: i32,
+}
+
+impl Observation {
+    /// Create an [`Observation`] from the raw snapshot data.
+    pub fn from_snapshot(snapshot: i32) -> Self {
+        Self { value: snapshot }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observation_wraps_snapshot_value() {
+        let obs = Observation::from_snapshot(7);
+        assert_eq!(obs.value, 7);
+    }
+}

--- a/crates/bot/src/perception/system.rs
+++ b/crates/bot/src/perception/system.rs
@@ -1,0 +1,41 @@
+//! Perception system updating observations and memory.
+
+use super::{BotMemory, Observation};
+
+/// Converts raw snapshots into observations while maintaining memory.
+#[derive(Debug, Default)]
+pub struct PerceptionSystem {
+    memory: BotMemory,
+}
+
+impl PerceptionSystem {
+    /// Create a new [`PerceptionSystem`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a snapshot, storing it in memory and returning the [`Observation`].
+    pub fn update(&mut self, snapshot: i32) -> Observation {
+        let obs = Observation::from_snapshot(snapshot);
+        self.memory.remember(obs);
+        obs
+    }
+
+    /// Access the underlying memory.
+    pub fn memory(&self) -> &BotMemory {
+        &self.memory
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_stores_observation_in_memory() {
+        let mut sys = PerceptionSystem::new();
+        let obs = sys.update(5);
+        assert_eq!(obs.value, 5);
+        assert_eq!(sys.memory().last().unwrap().value, 5);
+    }
+}

--- a/crates/bot/tests/perception_action.rs
+++ b/crates/bot/tests/perception_action.rs
@@ -1,0 +1,20 @@
+use bot::action::{Action, ActionExecutor, ActionResult};
+use bot::perception::PerceptionSystem;
+
+#[test]
+fn perception_system_records_observations() {
+    let mut sys = PerceptionSystem::new();
+    sys.update(1);
+    sys.update(2);
+    assert_eq!(sys.memory().len(), 2);
+    assert_eq!(sys.memory().last().unwrap().value, 2);
+}
+
+#[test]
+fn action_executor_updates_state() {
+    let exec = ActionExecutor::new();
+    let mut state = 0;
+    let res = exec.execute(&mut state, Action::Move(3));
+    assert_eq!(res, ActionResult::Success);
+    assert_eq!(state, 3);
+}


### PR DESCRIPTION
## Summary
- add perception system with observation processing and memory
- add action commands with executor and feedback
- document backlog item 26 completion

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_688e1de55678832d9279c3b53d050d17