### PR TITLE
Add RL environment and training utilities

### DIFF
--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -47,3 +47,4 @@ As new backlog features are completed, list them below with a reference to the b
 - AI modules with heuristic, reactive and planning strategies plus runtime switching ([Backlog #25](../backlog/backlog.md#25-bot-crate-%E2%80%93-ai-modules)).
 - Perception and action modules with memory and executor ([Backlog #26](../backlog/backlog.md#26-bot-crate-%E2%80%93-perception-and-action)).
 - RL policy and value estimation traits with Torch and random implementations ([Backlog #27](../backlog/backlog.md#27-rl-crate-%E2%80%93-policy-and-value-estimation)).
+- RL environment and training utilities with replay buffers ([Backlog #28](../backlog/backlog.md#28-rl-crate-%E2%80%93-environment-and-training)).

--- a/crates/rl/src/environment/env.rs
+++ b/crates/rl/src/environment/env.rs
@@ -1,0 +1,102 @@
+//! Simple gym-like environment for Bomberman training.
+
+use crate::{
+    error::RLError,
+    policy::Policy,
+    types::{Action, Observation, TrainingBatch},
+};
+
+use super::{ActionSpace, ObservationSpace, RewardCalculator};
+
+/// Minimal environment representing a 1D line with a goal position.
+pub struct RLEnvironment<R: RewardCalculator> {
+    position: i32,
+    goal: i32,
+    observation_space: ObservationSpace,
+    action_space: ActionSpace,
+    reward_calculator: R,
+    episode_length: u32,
+    current_step: u32,
+}
+
+impl<R: RewardCalculator> RLEnvironment<R> {
+    /// Create a new environment with the specified goal and episode length.
+    pub fn new(goal: i32, episode_length: u32, reward_calculator: R) -> Self {
+        Self {
+            position: 0,
+            goal,
+            observation_space: ObservationSpace { size: 1 },
+            action_space: ActionSpace { actions: 2 },
+            reward_calculator,
+            episode_length,
+            current_step: 0,
+        }
+    }
+
+    /// Reset the environment to the starting state returning the initial observation.
+    pub fn reset(&mut self) -> Observation {
+        self.position = 0;
+        self.current_step = 0;
+        self.get_observation()
+    }
+
+    /// Take a step in the environment using the provided action.
+    pub fn step(&mut self, action: Action) -> Result<(Observation, f32, bool), RLError> {
+        match action {
+            0 => self.position -= 1,
+            1 => self.position += 1,
+            _ => {}
+        }
+        if self.position < 0 {
+            self.position = 0;
+        }
+        if self.position > self.goal {
+            self.position = self.goal;
+        }
+        self.current_step += 1;
+        let done = self.position == self.goal || self.current_step >= self.episode_length;
+        let reward = self
+            .reward_calculator
+            .calculate(self.position, self.goal, done);
+        Ok((self.get_observation(), reward, done))
+    }
+
+    /// Return the observation for the current state.
+    fn get_observation(&self) -> Observation {
+        vec![self.position as f32 / self.goal as f32]
+    }
+
+    /// Run an episode using the provided policy collecting a batch of transitions.
+    pub fn run_episode<P: Policy>(
+        &mut self,
+        policy: &mut P,
+        max_steps: u32,
+    ) -> Result<TrainingBatch, RLError> {
+        let mut batch = TrainingBatch::default();
+        let mut obs = self.reset();
+        for _ in 0..max_steps {
+            let action = policy.select_action(&obs)?;
+            let (next_obs, reward, done) = self.step(action)?;
+            batch.observations.push(obs.clone());
+            batch.actions.push(action);
+            batch.rewards.push(reward);
+            batch.next_observations.push(next_obs.clone());
+            batch.dones.push(done);
+            obs = next_obs;
+            if done {
+                break;
+            }
+        }
+        Ok(batch)
+    }
+
+    /// Access the observation space.
+    pub fn observation_space(&self) -> ObservationSpace {
+        self.observation_space
+    }
+
+    /// Access the action space.
+    pub fn action_space(&self) -> ActionSpace {
+        self.action_space
+    }
+}

--- a/crates/rl/src/environment/mod.rs
+++ b/crates/rl/src/environment/mod.rs
@@ -1,0 +1,9 @@
+//! Reinforcement learning environment utilities.
+
+pub mod env;
+pub mod observation;
+pub mod reward;
+
+pub use env::RLEnvironment;
+pub use observation::{ActionSpace, ObservationSpace};
+pub use reward::{RewardCalculator, SimpleReward};

--- a/crates/rl/src/environment/observation.rs
+++ b/crates/rl/src/environment/observation.rs
@@ -1,0 +1,15 @@
+//! Definitions of observation and action spaces.
+
+/// Description of the observation vector shape.
+#[derive(Debug, Clone, Copy)]
+pub struct ObservationSpace {
+    /// Size of the observation vector.
+    pub size: usize,
+}
+
+/// Discrete action space description.
+#[derive(Debug, Clone, Copy)]
+pub struct ActionSpace {
+    /// Number of discrete actions available.
+    pub actions: i64,
+}

--- a/crates/rl/src/environment/reward.rs
+++ b/crates/rl/src/environment/reward.rs
@@ -1,0 +1,17 @@
+//! Reward calculation utilities.
+
+/// Trait for computing rewards given the environment state.
+pub trait RewardCalculator {
+    /// Calculate the reward for the current position.
+    fn calculate(&self, position: i32, goal: i32, done: bool) -> f32;
+}
+
+/// Simple reward: small negative per step, +1 on reaching goal.
+#[derive(Default)]
+pub struct SimpleReward;
+
+impl RewardCalculator for SimpleReward {
+    fn calculate(&self, position: i32, goal: i32, done: bool) -> f32 {
+        if done && position == goal { 1.0 } else { -0.01 }
+    }
+}

--- a/crates/rl/src/training/buffer.rs
+++ b/crates/rl/src/training/buffer.rs
@@ -1,0 +1,64 @@
+//! Simple in-memory replay buffer.
+
+use crate::types::{Action, Observation, TrainingBatch};
+
+/// Fixed-size replay buffer storing recent transitions.
+pub struct ReplayBuffer {
+    capacity: usize,
+    batch: TrainingBatch,
+}
+
+impl ReplayBuffer {
+    /// Create a new buffer with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            batch: TrainingBatch::default(),
+        }
+    }
+
+    /// Number of stored transitions.
+    pub fn len(&self) -> usize {
+        self.batch.actions.len()
+    }
+
+    /// Returns `true` if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Push a single transition into the buffer, evicting oldest if necessary.
+    pub fn push(
+        &mut self,
+        obs: Observation,
+        action: Action,
+        reward: f32,
+        next_obs: Observation,
+        done: bool,
+    ) {
+        if self.len() >= self.capacity {
+            self.batch.observations.remove(0);
+            self.batch.actions.remove(0);
+            self.batch.rewards.remove(0);
+            self.batch.next_observations.remove(0);
+            self.batch.dones.remove(0);
+        }
+        self.batch.observations.push(obs);
+        self.batch.actions.push(action);
+        self.batch.rewards.push(reward);
+        self.batch.next_observations.push(next_obs);
+        self.batch.dones.push(done);
+    }
+
+    /// Sample a batch of the most recent transitions.
+    pub fn sample(&self, batch_size: usize) -> TrainingBatch {
+        let start = self.len().saturating_sub(batch_size);
+        TrainingBatch {
+            observations: self.batch.observations[start..].to_vec(),
+            actions: self.batch.actions[start..].to_vec(),
+            rewards: self.batch.rewards[start..].to_vec(),
+            next_observations: self.batch.next_observations[start..].to_vec(),
+            dones: self.batch.dones[start..].to_vec(),
+        }
+    }
+}

--- a/crates/rl/src/training/mod.rs
+++ b/crates/rl/src/training/mod.rs
@@ -1,0 +1,7 @@
+//! Training utilities including replay buffers and loops.
+
+pub mod buffer;
+pub mod trainer;
+
+pub use buffer::ReplayBuffer;
+pub use trainer::Trainer;

--- a/crates/rl/src/training/trainer.rs
+++ b/crates/rl/src/training/trainer.rs
@@ -1,0 +1,63 @@
+//! Basic training loop using a replay buffer.
+
+use crate::{error::RLError, policy::Policy};
+
+use super::ReplayBuffer;
+use crate::environment::{RLEnvironment, RewardCalculator};
+
+/// Trainer coordinating environment interaction and policy updates.
+pub struct Trainer<P, R>
+where
+    P: Policy,
+    R: RewardCalculator,
+{
+    env: RLEnvironment<R>,
+    policy: P,
+    buffer: ReplayBuffer,
+}
+
+impl<P, R> Trainer<P, R>
+where
+    P: Policy,
+    R: RewardCalculator,
+{
+    /// Create a new trainer with the given components.
+    pub fn new(env: RLEnvironment<R>, policy: P, buffer_capacity: usize) -> Self {
+        Self {
+            env,
+            policy,
+            buffer: ReplayBuffer::new(buffer_capacity),
+        }
+    }
+
+    /// Run a number of training episodes.
+    pub fn train(
+        &mut self,
+        episodes: u32,
+        max_steps: u32,
+        batch_size: usize,
+    ) -> Result<(), RLError> {
+        for _ in 0..episodes {
+            let batch = self.env.run_episode(&mut self.policy, max_steps)?;
+            for i in 0..batch.actions.len() {
+                self.buffer.push(
+                    batch.observations[i].clone(),
+                    batch.actions[i],
+                    batch.rewards[i],
+                    batch.next_observations[i].clone(),
+                    batch.dones[i],
+                );
+            }
+            if self.buffer.len() >= batch_size {
+                let sample = self.buffer.sample(batch_size);
+                self.policy.update(&sample)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Access internal buffer for testing.
+    pub fn buffer(&self) -> &ReplayBuffer {
+        &self.buffer
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple Gym-style environment with reward calculation
- add replay buffer and trainer for RL loops
- document backlog item completion

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_688e23c09198832db2286380bc810e77