### PR TITLE
Integrate feature crates via event bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,8 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "bombs",
+ "events",
  "num_cpus",
  "rand 0.9.2",
  "serde",

--- a/Docs/completed/features.md
+++ b/Docs/completed/features.md
@@ -48,3 +48,4 @@ As new backlog features are completed, list them below with a reference to the b
 - Perception and action modules with memory and executor ([Backlog #26](../backlog/backlog.md#26-bot-crate-%E2%80%93-perception-and-action)).
 - RL policy and value estimation traits with Torch and random implementations ([Backlog #27](../backlog/backlog.md#27-rl-crate-%E2%80%93-policy-and-value-estimation)).
 - RL environment and training utilities with replay buffers ([Backlog #28](../backlog/backlog.md#28-rl-crate-%E2%80%93-environment-and-training)).
+- Engine integration of feature crates with event-driven flow ([Backlog #29](../backlog/backlog.md#29-engine-integration-of-feature-crates)).

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,3 +10,5 @@ state = { path = "../state" }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+events = { path = "../events" }
+bombs = { path = "../bombs" }

--- a/crates/engine/src/simulation/mod.rs
+++ b/crates/engine/src/simulation/mod.rs
@@ -15,7 +15,7 @@ mod tests {
             height: 1,
             ..EngineConfig::default()
         };
-        let (mut engine, _rx) = Engine::new(cfg.clone());
+        let (mut engine, _rx, _events) = Engine::new(cfg.clone());
         engine.add_system(Box::new(MovementSystem::new()));
         engine.start_replay_recording();
         for _ in 0..3 {
@@ -24,7 +24,7 @@ mod tests {
         let replay = engine.stop_replay_recording();
         let recorded_hashes = engine.determinism_hashes().to_vec();
 
-        let (mut engine2, _rx2) = Engine::new(cfg);
+        let (mut engine2, _rx2, _events2) = Engine::new(cfg);
         engine2.load_replay(&replay);
         assert_eq!(engine2.determinism_hashes(), recorded_hashes.as_slice());
     }

--- a/crates/engine/src/systems/bomb_system.rs
+++ b/crates/engine/src/systems/bomb_system.rs
@@ -1,16 +1,23 @@
 use std::sync::{Arc, RwLock};
 
+use bombs::bomb::entity::{Bomb, BombId};
+use events::{
+    bus::EventBus,
+    events::{Event, GameEvent},
+};
 use state::grid::{GameGrid, GridDelta, Tile};
 
 use super::System;
 
 /// Manages bomb placement and updates.
-pub struct BombSystem;
+pub struct BombSystem {
+    next_id: u32,
+}
 
 impl BombSystem {
     /// Create a new `BombSystem`.
     pub fn new() -> Self {
-        Self
+        Self { next_id: 0 }
     }
 }
 
@@ -19,7 +26,15 @@ impl System for BombSystem {
         "bomb"
     }
 
-    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta> {
+    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>, events: &EventBus) -> Option<GridDelta> {
+        let bomb = Bomb::new(BombId(self.next_id), 0, (0, 0), 3, 1);
+        self.next_id += 1;
+        events.broadcast(Event::Game(GameEvent::BombPlaced {
+            entity_id: bomb.owner,
+            bomb_id: bomb.id.0 as usize,
+            position: bomb.position,
+            power: bomb.power,
+        }));
         Some(GridDelta::SetTile {
             x: 1,
             y: 0,

--- a/crates/engine/src/systems/explosion.rs
+++ b/crates/engine/src/systems/explosion.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use events::bus::EventBus;
 use state::grid::{GameGrid, GridDelta, Tile};
 
 use super::System;
@@ -19,7 +20,7 @@ impl System for ExplosionSystem {
         "explosion"
     }
 
-    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta> {
+    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>, _events: &EventBus) -> Option<GridDelta> {
         Some(GridDelta::SetTile {
             x: 1,
             y: 0,

--- a/crates/engine/src/systems/mod.rs
+++ b/crates/engine/src/systems/mod.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, RwLock};
 
+use events::bus::EventBus;
 use state::grid::{GameGrid, GridDelta};
 
 /// Trait implemented by all engine systems.
@@ -9,7 +10,7 @@ pub trait System: Send {
     /// Name of the system.
     fn name(&self) -> &str;
     /// Run the system returning an optional grid delta to apply.
-    fn run(&mut self, grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta>;
+    fn run(&mut self, grid: &Arc<RwLock<GameGrid>>, events: &EventBus) -> Option<GridDelta>;
     /// Names of systems that must run before this one.
     fn dependencies(&self) -> &[&'static str] {
         &[]
@@ -45,7 +46,7 @@ mod tests {
             height: 2,
             ..EngineConfig::default()
         };
-        let (mut engine, _rx) = Engine::new(cfg);
+        let (mut engine, _rx, _events) = Engine::new(cfg);
         engine.add_system(Box::new(MovementSystem::new()));
         engine.add_system(Box::new(PlayerSystem::new()));
         engine.add_system(Box::new(BombSystem::new()));

--- a/crates/engine/src/systems/movement.rs
+++ b/crates/engine/src/systems/movement.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use events::bus::EventBus;
 use state::grid::{GameGrid, GridDelta, Tile};
 
 use super::System;
@@ -21,7 +22,7 @@ impl System for MovementSystem {
         "movement"
     }
 
-    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta> {
+    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>, _events: &EventBus) -> Option<GridDelta> {
         let tile = if self.toggle { Tile::Empty } else { Tile::Wall };
         self.toggle = !self.toggle;
         Some(GridDelta::SetTile { x: 0, y: 0, tile })

--- a/crates/engine/src/systems/player.rs
+++ b/crates/engine/src/systems/player.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use events::bus::EventBus;
 use state::grid::{GameGrid, GridDelta, Tile};
 
 use super::System;
@@ -19,7 +20,7 @@ impl System for PlayerSystem {
         "player"
     }
 
-    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta> {
+    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>, _events: &EventBus) -> Option<GridDelta> {
         Some(GridDelta::SetTile {
             x: 0,
             y: 0,

--- a/crates/engine/src/systems/powerup.rs
+++ b/crates/engine/src/systems/powerup.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use events::bus::EventBus;
 use state::grid::{GameGrid, GridDelta, Tile};
 
 use super::System;
@@ -19,7 +20,7 @@ impl System for PowerupSystem {
         "powerup"
     }
 
-    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>) -> Option<GridDelta> {
+    fn run(&mut self, _grid: &Arc<RwLock<GameGrid>>, _events: &EventBus) -> Option<GridDelta> {
         Some(GridDelta::SetTile {
             x: 1,
             y: 0,


### PR DESCRIPTION
## Summary
- wire engine to a shared EventBus and emit tick events
- hook bomb system into events crate and bombs crate
- document completed integration of feature crates

## Testing
- `cargo clippy --workspace --all-targets --all-features --exclude rl -- -D warnings`
- `cargo test --workspace --exclude rl`
- `cargo test -p engine tick_emits_game_event -- --nocapture`
- `cargo test -p engine bomb_system_emits_event -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_688e267677bc832da74407e17608b4f1