### PR TITLE
feat: add unified system initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,14 +419,41 @@ dependencies = [
  "bombs",
  "bot",
  "crossbeam",
+ "env_logger",
  "events",
+ "log",
  "num_cpus",
  "rand 0.9.2",
  "serde",
  "serde_json",
  "state",
+ "tempfile",
  "thiserror",
  "tokio",
+ "toml",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -408,6 +491,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ffi"
 version = "0.1.0"
+dependencies = [
+ "engine",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -530,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +638,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -702,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +929,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1117,6 +1257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1456,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "torch-sys"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1536,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -1573,6 +1769,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,8 +10,14 @@ state = { path = "../state" }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+toml = "0.8"
 events = { path = "../events" }
 bombs = { path = "../bombs" }
 crossbeam = { workspace = true }
 bot = { path = "../bot" }
 thiserror = { workspace = true }
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/engine/src/config/mod.rs
+++ b/crates/engine/src/config/mod.rs
@@ -1,5 +1,10 @@
 pub mod engine_config;
 pub mod game_rules;
+pub mod unified_config;
 
-pub use engine_config::{ConfigError, EngineConfig};
+pub use engine_config::EngineConfig;
 pub use game_rules::GameRules;
+pub use unified_config::{
+    AIConfig, BombConfig, BotConfig as UnifiedBotConfig, ConfigError, EventBusConfig,
+    LoggingConfig, RLConfig, TournamentConfig, UnifiedConfig,
+};

--- a/crates/engine/src/config/unified_config.rs
+++ b/crates/engine/src/config/unified_config.rs
@@ -1,0 +1,181 @@
+use std::{fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::engine_config::EngineConfig;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("toml parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("json parse error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid configuration: {0}")]
+    Invalid(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBusConfig {
+    pub buffer_size: usize,
+    pub max_subscribers: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BotConfig {
+    pub name: String,
+    pub ai_type: String,
+    pub rl_mode: bool,
+    pub rl_model_path: Option<String>,
+    pub decision_timeout_ms: u64,
+}
+
+impl BotConfig {
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.name.trim().is_empty() {
+            return Err(ConfigError::Invalid("bot name cannot be empty".into()));
+        }
+        if self.rl_mode && self.rl_model_path.is_none() {
+            return Err(ConfigError::Invalid(
+                "rl_mode enabled but rl_model_path missing".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TournamentConfig {
+    pub rounds: u32,
+    pub games_per_round: u32,
+    pub scoring_system: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AIConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RLConfig {
+    pub model_path: String,
+}
+
+impl RLConfig {
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if !Path::new(&self.model_path).exists() {
+            return Err(ConfigError::Invalid(format!(
+                "rl model path not found: {}",
+                self.model_path
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BombConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LoggingConfig {
+    pub level: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnifiedConfig {
+    pub engine: EngineConfig,
+    pub event_bus: EventBusConfig,
+    pub bots: Vec<BotConfig>,
+    pub tournament: Option<TournamentConfig>,
+    pub ai: AIConfig,
+    pub rl: Option<RLConfig>,
+    pub bombs: BombConfig,
+    pub logging: LoggingConfig,
+}
+
+impl UnifiedConfig {
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        self.engine.validate()?;
+        for bot in &self.bots {
+            bot.validate()?;
+        }
+        if let Some(rl) = &self.rl {
+            rl.validate()?;
+        }
+        self.validate_consistency()
+    }
+
+    fn validate_consistency(&self) -> Result<(), ConfigError> {
+        if self.bots.len() > self.engine.rules.max_players as usize {
+            return Err(ConfigError::Invalid(
+                "number of bots exceeds engine rules".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn from_file(path: &str) -> Result<Self, ConfigError> {
+        let content = fs::read_to_string(path)?;
+        let config: Self = if path.ends_with(".toml") {
+            toml::from_str(&content)?
+        } else {
+            serde_json::from_str(&content)?
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn with_env_overrides(mut self) -> Result<Self, ConfigError> {
+        if let Ok(level) = std::env::var("BOMBER_LOG_LEVEL") {
+            self.logging.level = level;
+        }
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn load_and_validate_from_json() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "{}", r#"{
+            "engine":{"width":5,"height":5,"tick_rate":60,"rules":{"max_players":4,"bomb_timer":3,"starting_lives":3}},
+            "event_bus":{"buffer_size":10,"max_subscribers":10},
+            "bots":[{"name":"b1","ai_type":"Heuristic","rl_mode":false,"rl_model_path":null,"decision_timeout_ms":5}],
+            "tournament":null,
+            "ai":{},
+            "rl":null,
+            "bombs":{},
+            "logging":{"level":"info"}
+        }"#).unwrap();
+        let path = file.into_temp_path();
+        let cfg = UnifiedConfig::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(cfg.bots.len(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_missing_rl_model() {
+        let cfg = UnifiedConfig {
+            engine: EngineConfig::default(),
+            event_bus: EventBusConfig {
+                buffer_size: 1,
+                max_subscribers: 1,
+            },
+            bots: vec![],
+            tournament: None,
+            ai: AIConfig::default(),
+            rl: Some(RLConfig {
+                model_path: "missing".into(),
+            }),
+            bombs: BombConfig::default(),
+            logging: LoggingConfig {
+                level: "info".into(),
+            },
+        };
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -10,9 +10,193 @@ pub mod shrink;
 pub mod simulation;
 pub mod systems;
 
-pub use ::bot::BotConfig;
+use std::sync::{Arc, RwLock};
+
+use events::bus::EventBus;
+use state::GameGrid;
+
+pub use ::bot::BotConfig as BotRuntimeConfig;
 pub use bot::{BotError, BotHandle, BotManager};
-pub use config::{ConfigError, EngineConfig, GameRules};
+pub use config::{
+    AIConfig, BombConfig, ConfigError, EngineConfig, EventBusConfig, GameRules, LoggingConfig,
+    RLConfig, TournamentConfig, UnifiedBotConfig, UnifiedConfig,
+};
 pub use engine::{Engine, TaskScheduler};
 pub use simulation::{DeterminismChecker, Replay, ReplayRecorder};
 pub use systems::System;
+
+/// Errors that may occur during system initialization.
+#[derive(Debug, thiserror::Error)]
+pub enum InitializationError {
+    #[error("configuration error: {0}")]
+    Config(#[from] ConfigError),
+    #[error("bot initialization error: {0}")]
+    Bot(String),
+    #[error("engine initialization failed")]
+    Engine,
+}
+
+/// Handle returned after successful system initialization.
+pub struct SystemHandle {
+    event_bus: Arc<EventBus>,
+    engine: Engine,
+    bot_count: usize,
+    tournament: Option<TournamentConfig>,
+}
+
+impl SystemHandle {
+    fn new(
+        event_bus: Arc<EventBus>,
+        engine: Engine,
+        bot_count: usize,
+        tournament: Option<TournamentConfig>,
+    ) -> Self {
+        Self {
+            event_bus,
+            engine,
+            bot_count,
+            tournament,
+        }
+    }
+
+    /// Access the initialized engine.
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Consume the handle returning the engine.
+    pub fn into_engine(self) -> Engine {
+        self.engine
+    }
+
+    /// Check if a tournament is configured.
+    pub fn has_tournament(&self) -> bool {
+        self.tournament.is_some()
+    }
+
+    /// Access the event bus.
+    pub fn event_bus(&self) -> &EventBus {
+        &self.event_bus
+    }
+
+    /// Number of bots initialized.
+    pub fn bot_count(&self) -> usize {
+        self.bot_count
+    }
+}
+
+/// Initializes the entire Bomberman system from a unified configuration.
+pub struct SystemInitializer {
+    config: UnifiedConfig,
+    event_bus: Option<Arc<EventBus>>,
+    game_grid: Option<Arc<RwLock<GameGrid>>>,
+    engine: Option<Engine>,
+    bot_count: usize,
+}
+
+impl SystemInitializer {
+    /// Create a new initializer from configuration.
+    pub fn new(config: UnifiedConfig) -> Self {
+        Self {
+            config,
+            event_bus: None,
+            game_grid: None,
+            engine: None,
+            bot_count: 0,
+        }
+    }
+
+    /// Run the initialization pipeline.
+    pub async fn initialize(&mut self) -> Result<SystemHandle, InitializationError> {
+        self.initialize_event_bus().await?;
+        self.initialize_game_state().await?;
+        self.initialize_engine().await?;
+        self.initialize_ai_components().await?;
+        self.initialize_bots().await?;
+        let tournament = self.config.tournament.clone();
+        Ok(SystemHandle::new(
+            Arc::clone(self.event_bus.as_ref().unwrap()),
+            self.engine.take().unwrap(),
+            self.bot_count,
+            tournament,
+        ))
+    }
+
+    async fn initialize_event_bus(&mut self) -> Result<(), InitializationError> {
+        let bus = EventBus::new();
+        self.event_bus = Some(Arc::new(bus));
+        Ok(())
+    }
+
+    async fn initialize_game_state(&mut self) -> Result<(), InitializationError> {
+        let grid = GameGrid::new(self.config.engine.width, self.config.engine.height);
+        self.game_grid = Some(Arc::new(RwLock::new(grid)));
+        Ok(())
+    }
+
+    async fn initialize_engine(&mut self) -> Result<(), InitializationError> {
+        let events = Arc::clone(self.event_bus.as_ref().ok_or(InitializationError::Engine)?);
+        let grid = Arc::clone(self.game_grid.as_ref().ok_or(InitializationError::Engine)?);
+        let (engine, _rx) =
+            engine::Engine::with_components(self.config.engine.clone(), grid, events);
+        self.engine = Some(engine);
+        Ok(())
+    }
+
+    async fn initialize_ai_components(&mut self) -> Result<(), InitializationError> {
+        // Placeholder for AI component initialization
+        Ok(())
+    }
+
+    async fn initialize_bots(&mut self) -> Result<(), InitializationError> {
+        use ::bot::AiType;
+        let engine = self.engine.as_mut().ok_or(InitializationError::Engine)?;
+        for cfg in &self.config.bots {
+            let mut bot_cfg = ::bot::BotConfig::new(
+                &cfg.name,
+                match cfg.ai_type.as_str() {
+                    "Reactive" => AiType::Reactive,
+                    _ => AiType::Heuristic,
+                },
+            );
+            bot_cfg.rl_mode = cfg.rl_mode;
+            bot_cfg.rl_model_path = cfg.rl_model_path.clone();
+            bot_cfg.decision_timeout = std::time::Duration::from_millis(cfg.decision_timeout_ms);
+            if let Err(e) = engine.spawn_bot(bot_cfg) {
+                return Err(InitializationError::Bot(e.to_string()));
+            }
+            self.bot_count += 1;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initializes_system_with_single_bot() {
+        let cfg = UnifiedConfig {
+            engine: EngineConfig::default(),
+            event_bus: EventBusConfig {
+                buffer_size: 1,
+                max_subscribers: 1,
+            },
+            bots: vec![],
+            tournament: None,
+            ai: AIConfig::default(),
+            rl: None,
+            bombs: BombConfig::default(),
+            logging: LoggingConfig {
+                level: "info".into(),
+            },
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let handle = rt.block_on(async {
+            let mut init = SystemInitializer::new(cfg);
+            init.initialize().await.unwrap()
+        });
+        assert!(!handle.has_tournament());
+    }
+}

--- a/crates/engine/src/main.rs
+++ b/crates/engine/src/main.rs
@@ -1,22 +1,35 @@
-use bot::AiType;
-use engine::{BotConfig, Engine, EngineConfig};
+use engine::{SystemInitializer, UnifiedConfig};
+use log::info;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut engine, _rx, _events) = Engine::new(EngineConfig::default());
-    let bot_configs = vec![
-        BotConfig::new("bot1", AiType::Heuristic),
-        BotConfig::new("bot2", AiType::Reactive),
-    ];
-
-    for cfg in bot_configs {
-        if let Err(e) = engine.spawn_bot(cfg) {
-            eprintln!("failed to spawn bot: {}", e);
-        }
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let config_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "config/default.toml".to_string());
+    let mut config = UnifiedConfig::from_file(&config_path)?;
+    config = config.with_env_overrides()?;
+    info!("Loaded configuration from {}", config_path);
+    let mut initializer = SystemInitializer::new(config);
+    let handle = initializer.initialize().await?;
+    info!("System initialized successfully");
+    if handle.has_tournament() {
+        run_tournament(handle).await?;
+    } else {
+        run_single_game(handle).await?;
     }
+    Ok(())
+}
 
+async fn run_single_game(handle: engine::SystemHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let mut engine = handle.into_engine();
     for _ in 0..10 {
         engine.tick();
     }
-
     Ok(())
+}
+
+async fn run_tournament(handle: engine::SystemHandle) -> Result<(), Box<dyn std::error::Error>> {
+    // Placeholder tournament execution; reuse single game for now
+    run_single_game(handle).await
 }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+engine = { path = "../engine" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,8 +1,37 @@
-//! Temporary skeleton crate
-#![warn(missing_docs, clippy::all)]
-/// Initializes the crate and returns a greeting.
-pub fn init() -> &'static str {
-    "initialized"
+//! FFI bindings for initializing the Bomberman system.
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use engine::{SystemHandle, SystemInitializer, UnifiedConfig};
+use tokio::runtime::Runtime;
+
+/// Initialize the Bomberman system from a JSON configuration string.
+/// # Safety
+/// `config_json` must be a valid null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bomberman_init(config_json: *const c_char) -> *mut SystemHandle {
+    let config_str = unsafe { CStr::from_ptr(config_json).to_string_lossy().to_string() };
+    let config: UnifiedConfig =
+        serde_json::from_str(&config_str).expect("Invalid configuration JSON");
+    let mut initializer = SystemInitializer::new(config);
+    let rt = Runtime::new().expect("runtime");
+    let handle = rt
+        .block_on(initializer.initialize())
+        .expect("Failed to initialize system");
+    Box::into_raw(Box::new(handle))
+}
+
+/// Shutdown the Bomberman system, freeing resources.
+/// # Safety
+/// `handle` must be a pointer obtained from [`bomberman_init`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bomberman_shutdown(handle: *mut SystemHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -10,7 +39,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn init_returns_initialized() {
-        assert_eq!(init(), "initialized");
+    fn init_and_shutdown_via_ffi() {
+        let json = r#"{
+            "engine":{"width":5,"height":5,"tick_rate":60,"rules":{"max_players":4,"bomb_timer":3,"starting_lives":3}},
+            "event_bus":{"buffer_size":10,"max_subscribers":10},
+            "bots":[],
+            "tournament":null,
+            "ai":{},
+            "rl":null,
+            "bombs":{},
+            "logging":{"level":"info"}
+        }"#;
+        let cstr = std::ffi::CString::new(json).unwrap();
+        let ptr = unsafe { bomberman_init(cstr.as_ptr()) };
+        assert!(!ptr.is_null());
+        unsafe { bomberman_shutdown(ptr) };
     }
 }


### PR DESCRIPTION
## Summary
- add unified configuration with validation and environment overrides
- centralize startup logic with a SystemInitializer and handle
- expose FFI init/shutdown for external integrations

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p engine`
- `cargo test -p ffi -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_688f2a535f88832d871ff4e546d3e2a6