### PR TITLE
feat: add shared diagnostics and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +253,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +281,27 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "common"
+version = "0.1.0"
+dependencies = [
+ "bot",
+ "chrono",
+ "engine",
+ "env_logger 0.10.2",
+ "events",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -419,7 +468,7 @@ dependencies = [
  "bombs",
  "bot",
  "crossbeam",
- "env_logger",
+ "env_logger 0.11.8",
  "events",
  "log",
  "num_cpus",
@@ -441,6 +490,19 @@ checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -480,6 +542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "state",
+ "thiserror",
 ]
 
 [[package]]
@@ -588,6 +651,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +709,17 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1371,6 +1475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test_utils"
 version = "0.1.0"
 
@@ -1687,6 +1800,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/rl",
     "crates/test_utils",
     "crates/ffi",
+    "crates/common",
 ]
 resolver = "2"
 
@@ -31,3 +32,6 @@ bincode = "1"
 thiserror = "1"
 rand = "0.8"
 tempfile = "3"
+log = "0.4"
+env_logger = "0.10"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }

--- a/crates/bot/src/error.rs
+++ b/crates/bot/src/error.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+/// Errors that may occur within the bot crate.
+#[derive(Debug, Error)]
+pub enum BotError {
+    /// Subscribing to events failed.
+    #[error("Event subscription failed: {0}")]
+    EventSubscription(String),
+    /// The bot failed to make a decision within the timeout.
+    #[error("Decision timeout after {timeout_ms}ms")]
+    DecisionTimeout {
+        /// Timeout in milliseconds.
+        timeout_ms: u64,
+    },
+    /// The AI pipeline returned an error.
+    #[error("AI decision failed: {0}")]
+    AIDecision(String),
+    /// Sending a command to the engine failed.
+    #[error("Command send failed: {0}")]
+    CommandSend(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_variants() {
+        let e = BotError::DecisionTimeout { timeout_ms: 5 };
+        assert_eq!(format!("{}", e), "Decision timeout after 5ms");
+    }
+}

--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -8,12 +8,15 @@ pub mod action;
 pub mod ai;
 /// Bot kernel and related types.
 pub mod bot;
+/// Common error types for the bot crate.
+pub mod error;
 /// Perception system converting snapshots into observations.
 pub mod perception;
 
 pub use action::{Action, ActionExecutor, ActionResult};
 pub use ai::{AiType, HeuristicAI, PlanningAI, ReactiveAI, SwitchingAI};
 pub use bot::{Bot, BotConfig, BotState, DecisionMaker};
+pub use error::BotError;
 pub use perception::{BotMemory, Observation, PerceptionSystem};
 
 /// Initializes the crate and returns a greeting.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+chrono = { workspace = true }
+engine = { path = "../engine" }
+bot = { path = "../bot" }
+events = { path = "../events" }
+

--- a/crates/common/src/diagnostics.rs
+++ b/crates/common/src/diagnostics.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+pub struct HealthChecker {
+    components: HashMap<String, Box<dyn HealthCheck>>,
+}
+
+pub trait HealthCheck: Send + Sync {
+    fn name(&self) -> &str;
+    fn check_health(&self) -> HealthStatus;
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct HealthStatus {
+    pub component: String,
+    pub status: Status,
+    pub details: Option<String>,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub enum Status {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl HealthChecker {
+    pub fn new() -> Self {
+        Self {
+            components: HashMap::new(),
+        }
+    }
+
+    pub fn register_check(&mut self, name: String, check: Box<dyn HealthCheck>) {
+        self.components.insert(name, check);
+    }
+
+    pub fn check_all(&self) -> Vec<HealthStatus> {
+        self.components.values().map(|c| c.check_health()).collect()
+    }
+
+    pub fn overall_health(&self) -> Status {
+        let statuses = self.check_all();
+        if statuses
+            .iter()
+            .any(|s| matches!(s.status, Status::Unhealthy))
+        {
+            Status::Unhealthy
+        } else if statuses
+            .iter()
+            .any(|s| matches!(s.status, Status::Degraded))
+        {
+            Status::Degraded
+        } else {
+            Status::Healthy
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyCheck(Status);
+
+    impl HealthCheck for DummyCheck {
+        fn name(&self) -> &str {
+            "dummy"
+        }
+
+        fn check_health(&self) -> HealthStatus {
+            HealthStatus {
+                component: self.name().to_string(),
+                status: self.0.clone(),
+                details: None,
+                timestamp: chrono::Utc::now(),
+            }
+        }
+    }
+
+    #[test]
+    fn overall_health_reports_worst_status() {
+        let mut checker = HealthChecker::new();
+        checker.register_check("a".into(), Box::new(DummyCheck(Status::Healthy)));
+        checker.register_check("b".into(), Box::new(DummyCheck(Status::Degraded)));
+        assert_eq!(checker.overall_health(), Status::Degraded);
+        checker.register_check("c".into(), Box::new(DummyCheck(Status::Unhealthy)));
+        assert_eq!(checker.overall_health(), Status::Unhealthy);
+    }
+}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,62 @@
+use thiserror::Error;
+
+use bot::error::BotError;
+use engine::config::ConfigError;
+use engine::engine::game_engine::EngineError;
+use events::error::EventBusError; // engine config error
+
+pub type Result<T> = std::result::Result<T, BombermanError>;
+
+#[derive(Debug, Error)]
+pub enum BombermanError {
+    #[error("Configuration error: {0}")]
+    Config(#[from] ConfigError),
+    #[error("Engine error: {0}")]
+    Engine(#[from] EngineError),
+    #[error("Bot error: {0}")]
+    Bot(#[from] BotError),
+    #[error("Event bus error: {0}")]
+    EventBus(#[from] EventBusError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Unknown error: {0}")]
+    Unknown(String),
+}
+
+impl BombermanError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            BombermanError::Config(_) => 1000,
+            BombermanError::Engine(_) => 2000,
+            BombermanError::Bot(_) => 3000,
+            BombermanError::EventBus(_) => 4000,
+            BombermanError::Io(_) => 5000,
+            BombermanError::Serialization(_) => 6000,
+            BombermanError::Unknown(_) => 9999,
+        }
+    }
+
+    pub fn is_recoverable(&self) -> bool {
+        matches!(
+            self,
+            BombermanError::EventBus(_) | BombermanError::Bot(BotError::DecisionTimeout { .. })
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_and_recoverable() {
+        let err = BombermanError::Bot(BotError::DecisionTimeout { timeout_ms: 10 });
+        assert_eq!(err.error_code(), 3000);
+        assert!(err.is_recoverable());
+        let err = BombermanError::Config(ConfigError::Invalid("x".into()));
+        assert_eq!(err.error_code(), 1000);
+        assert!(!err.is_recoverable());
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,0 +1,7 @@
+#![forbid(unsafe_code)]
+
+pub mod diagnostics;
+pub mod error;
+pub mod logging;
+
+pub use error::{BombermanError, Result};

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -1,0 +1,79 @@
+use log::{info, Level};
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct LoggingConfig {
+    pub level: Level,
+    pub json_format: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum LoggingError {
+    #[error("logger initialization failed")]
+    Init,
+}
+
+pub fn init_logging(config: &LoggingConfig) -> Result<(), LoggingError> {
+    let level = config.level.to_level_filter();
+    let format = if config.json_format {
+        formatting::json_format
+    } else {
+        formatting::text_format
+    };
+
+    env_logger::Builder::new()
+        .filter_level(level)
+        .format(format)
+        .target(env_logger::Target::Stdout)
+        .try_init()
+        .map_err(|_| LoggingError::Init)?;
+
+    info!("Logging initialized with level: {}", level);
+    Ok(())
+}
+
+pub mod formatting {
+    use log::Record;
+    use std::io::Write;
+
+    pub fn json_format(
+        buf: &mut env_logger::fmt::Formatter,
+        record: &Record,
+    ) -> std::io::Result<()> {
+        writeln!(
+            buf,
+            "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"target\":\"{}\",\"message\":\"{}\"}}",
+            chrono::Utc::now().to_rfc3339(),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    }
+
+    pub fn text_format(
+        buf: &mut env_logger::fmt::Formatter,
+        record: &Record,
+    ) -> std::io::Result<()> {
+        writeln!(
+            buf,
+            "[{}] {}: {}",
+            chrono::Utc::now().to_rfc3339(),
+            record.level(),
+            record.args()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initializes_logger() {
+        let cfg = LoggingConfig {
+            level: Level::Info,
+            json_format: false,
+        };
+        let _ = init_logging(&cfg);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -22,6 +22,7 @@ pub use config::{
     AIConfig, BombConfig, ConfigError, EngineConfig, EventBusConfig, GameRules, LoggingConfig,
     RLConfig, TournamentConfig, UnifiedBotConfig, UnifiedConfig,
 };
+pub use engine::game_engine::EngineError;
 pub use engine::{Engine, TaskScheduler};
 pub use simulation::{DeterminismChecker, Replay, ReplayRecorder};
 pub use systems::System;

--- a/crates/engine/src/main.rs
+++ b/crates/engine/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_single_game(handle: engine::SystemHandle) -> Result<(), Box<dyn std::error::Error>> {
     let mut engine = handle.into_engine();
     for _ in 0..10 {
-        engine.tick();
+        engine.tick().unwrap();
     }
     Ok(())
 }

--- a/crates/engine/src/simulation/mod.rs
+++ b/crates/engine/src/simulation/mod.rs
@@ -19,7 +19,7 @@ mod tests {
         engine.add_system(Box::new(MovementSystem::new()));
         engine.start_replay_recording();
         for _ in 0..3 {
-            engine.tick();
+            engine.tick().unwrap();
         }
         let replay = engine.stop_replay_recording();
         let recorded_hashes = engine.determinism_hashes().to_vec();

--- a/crates/engine/src/systems/mod.rs
+++ b/crates/engine/src/systems/mod.rs
@@ -53,7 +53,7 @@ mod tests {
         engine.add_system(Box::new(ExplosionSystem::new()));
         engine.add_system(Box::new(PowerupSystem::new()));
 
-        engine.tick();
+        engine.tick().unwrap();
 
         let grid_arc = engine.grid();
         let grid = grid_arc.read().unwrap();

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -8,3 +8,4 @@ crossbeam = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 state = { path = "../state" }
+thiserror = { workspace = true }

--- a/crates/events/src/error.rs
+++ b/crates/events/src/error.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+
+/// Errors that can occur when using the [`EventBus`](crate::EventBus).
+#[derive(Debug, Error)]
+pub enum EventBusError {
+    /// Too many subscribers are registered.
+    #[error("Subscription limit exceeded: {current}/{max}")]
+    SubscriptionLimit {
+        /// Number of current subscribers.
+        current: usize,
+        /// Maximum allowed subscribers.
+        max: usize,
+    },
+    /// Serializing an event failed.
+    #[error("Event serialization failed: {0}")]
+    Serialization(String),
+    /// Deserializing an event failed.
+    #[error("Event deserialization failed: {0}")]
+    Deserialization(String),
+    /// The broadcast queue is full.
+    #[error("Broadcast queue full: {current}/{max}")]
+    BroadcastQueueFull {
+        /// Current queue size.
+        current: usize,
+        /// Maximum queue capacity.
+        max: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_variant() {
+        let e = EventBusError::BroadcastQueueFull {
+            current: 10,
+            max: 5,
+        };
+        assert!(format!("{}", e).contains("10/5"));
+    }
+}

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -4,11 +4,14 @@
 //! Event definitions and bus for the Bomberman project.
 
 pub mod bus;
+/// Error types for the event bus.
+pub mod error;
 pub mod events;
 pub mod queue;
 pub mod serialization;
 
 pub use bus::{EventBus, EventFilter, SubscriberId};
+pub use error::EventBusError;
 pub use events::{BombEvent, BotDecision, BotEvent, Event, GameEvent, PowerUpType, SystemEvent};
 pub use queue::EventPriority;
 pub use serialization::{Transition, TransitionRecorder, decoder, encoder};


### PR DESCRIPTION
## Summary
- introduce `common` crate with unified error type, logging config, and health check utilities
- add concrete error enums for engine, bot, and event bus modules
- refactor engine tick to return `Result` and expose `EngineError`

## Testing
- `cargo clippy --all-targets --all-features` *(fails: torch-sys missing libtorch)*
- `cargo test --all` *(hangs on rl tests; interrupted after 60s)*
- `cargo test -p common`


------
https://chatgpt.com/codex/tasks/task_e_688f90e619dc832d90dc18727022633d