### PR TITLE
Add basic testing utilities and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ version = "0.1.0"
 dependencies = [
  "bombs",
  "bot",
+ "criterion",
  "crossbeam",
  "env_logger",
  "events",
@@ -1751,6 +1752,9 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
+dependencies = [
+ "events",
+]
 
 [[package]]
 name = "textwrap"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.11"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+criterion = { workspace = true }
 
 [features]
 default = ["tournament"]

--- a/crates/engine/benches/performance_benchmarks.rs
+++ b/crates/engine/benches/performance_benchmarks.rs
@@ -1,0 +1,14 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use engine::{Engine, config::EngineConfig};
+
+fn engine_tick_benchmark(c: &mut Criterion) {
+    c.bench_function("engine_tick", |b| {
+        b.iter(|| {
+            let (mut engine, _rx, _events) = Engine::new(EngineConfig::default());
+            engine.tick().unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, engine_tick_benchmark);
+criterion_main!(benches);

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+events = { path = "../events" }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -1,6 +1,58 @@
-//! Temporary skeleton crate
+//! Test utilities and mocks used across integration tests.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, clippy::all)]
+
+use std::time::Duration;
+
+/// Module containing simple mock types.
+pub mod mocks {
+    use events::events::Event;
+    use std::sync::Mutex;
+
+    /// Mock event bus that stores broadcast events for inspection.
+    #[derive(Default)]
+    pub struct MockEventBus {
+        events: Mutex<Vec<Event>>,
+    }
+
+    impl MockEventBus {
+        /// Create a new empty mock bus.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Record a broadcast event.
+        pub fn broadcast(&self, event: Event) {
+            self.events.lock().expect("lock").push(event);
+        }
+
+        /// Retrieve all recorded events.
+        pub fn events(&self) -> Vec<Event> {
+            self.events.lock().expect("lock").clone()
+        }
+
+        /// Clear all stored events.
+        pub fn clear(&self) {
+            self.events.lock().expect("lock").clear();
+        }
+    }
+}
+
+/// Assertion helpers used in tests.
+pub mod assertions {
+    use std::time::Duration;
+
+    /// Assert that a duration is within an expected bound.
+    pub fn assert_performance_within_bounds(duration: Duration, max: Duration) {
+        assert!(
+            duration <= max,
+            "Performance exceeded bounds: {:?} > {:?}",
+            duration,
+            max
+        );
+    }
+}
+
 /// Initializes the crate and returns a greeting.
 pub fn init() -> &'static str {
     "initialized"
@@ -9,9 +61,22 @@ pub fn init() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use events::events::GameEvent;
 
     #[test]
     fn init_returns_initialized() {
         assert_eq!(init(), "initialized");
+    }
+
+    #[test]
+    fn mock_event_bus_records_events() {
+        use events::events::Event;
+        use mocks::MockEventBus;
+
+        let bus = MockEventBus::new();
+        bus.broadcast(Event::Game(GameEvent::TickCompleted { tick: 1 }));
+        assert_eq!(bus.events().len(), 1);
+        bus.clear();
+        assert!(bus.events().is_empty());
     }
 }

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -1,0 +1,18 @@
+use engine::{Engine, config::EngineConfig};
+use events::{events::{Event, GameEvent}, queue::EventPriority};
+
+#[test]
+fn event_bus_handles_many_subscribers() {
+    use events::bus::EventBus;
+    let bus = EventBus::new();
+    for _ in 0..100 {
+        bus.subscribe();
+    }
+    bus.broadcast(Event::Game(GameEvent::TickCompleted { tick: 1 }));
+}
+
+#[test]
+fn engine_stays_healthy_under_empty_tick() {
+    let (mut engine, _rx, _events) = Engine::new(EngineConfig::default());
+    engine.tick().unwrap();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,24 @@
+use engine::{Engine, config::EngineConfig};
+use events::{events::{Event, GameEvent, BotEvent, BotDecision}, queue::EventPriority};
+use state::grid::GridDelta;
+
+#[test]
+fn test_event_broadcast_and_reception() {
+    let (mut engine, _rx, events) = Engine::new(EngineConfig::default());
+    let (_id, rx) = events.subscribe();
+    engine.tick().unwrap();
+    let event = rx.try_recv().unwrap();
+    assert!(matches!(event, Event::Game(GameEvent::TickCompleted { .. })));
+}
+
+#[test]
+fn test_bot_command_processing() {
+    let cfg = EngineConfig { width: 1, height: 1, ..EngineConfig::default() };
+    let (mut engine, mut rx, events) = Engine::new(cfg);
+    events.emit(
+        Event::Bot(BotEvent::Decision { bot_id: 0, decision: BotDecision::PlaceBomb }),
+        EventPriority::Normal,
+    );
+    engine.tick().unwrap();
+    assert!(matches!(rx.borrow_and_update().clone(), GridDelta::AddBomb(_)));
+}


### PR DESCRIPTION
## Summary
- add integration tests covering event broadcast and bot command processing
- introduce basic mock event bus and assertions for tests
- add criterion benchmark for engine tick performance

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: this tch version expects PyTorch 2.0.0, got 2.2.0)*
- `cargo test --workspace --exclude rl` *(fails: unresolved import `rl`)*
- `cargo bench -p engine --bench performance_benchmarks -- --nocapture` *(fails: unresolved import `rl`)*

------
https://chatgpt.com/codex/tasks/task_e_688fd71a78ac832da25ad34ce54bc858